### PR TITLE
Transcribe Videos with Sapat in Daytona

### DIFF
--- a/authors/godd-ctrl.md
+++ b/authors/godd-ctrl.md
@@ -1,0 +1,10 @@
+Author: [godd-ctrl](https://github.com/godd-ctrl)
+Title: Technical Writer and Developer
+Description: Technical writer and developer focused on reproducible developer environments, AI tooling, automation, and practical guides that help engineers move from setup to working software with fewer local-machine surprises.
+Author Image: [GitHub avatar](https://github.com/godd-ctrl.png)
+Author LinkedIn:
+Author Twitter:
+Company Name: Independent
+Company Description: Independent software and technical writing contributor.
+Company Logo Dark:
+Company Logo White:

--- a/definitions/20260510_definition_speech_to_text.md
+++ b/definitions/20260510_definition_speech_to_text.md
@@ -1,0 +1,24 @@
+---
+title: 'Speech-to-Text'
+description: 'Speech-to-text converts spoken audio into written text.'
+date: 2026-05-10
+author: 'godd-ctrl'
+---
+
+# Speech-to-Text
+
+## Definition
+
+Speech-to-text is the process of converting spoken language from audio or video
+into written text. Modern speech-to-text systems usually use machine learning
+models to identify words, punctuation, pauses, and sometimes speaker or segment
+boundaries.
+
+## Context and Usage
+
+Developers use speech-to-text when building transcription tools, meeting
+summaries, searchable video archives, accessibility workflows, and data
+preparation pipelines for AI applications. A reproducible development
+environment is useful because audio tooling often depends on operating system
+packages such as ffmpeg, provider credentials, and consistent Python
+dependencies.

--- a/guides/20260510_guide_transcribe_videos_with_sapat_and_daytona.md
+++ b/guides/20260510_guide_transcribe_videos_with_sapat_and_daytona.md
@@ -1,0 +1,356 @@
+---
+title: 'Transcribe Videos with Sapat in Daytona'
+description: 'Build a reproducible Daytona workspace for Sapat, ffmpeg, and OpenAI, Groq, or Azure OpenAI transcription workflows.'
+date: 2026-05-10
+author: 'godd-ctrl'
+tags: ['daytona', 'sapat', 'transcription', 'openai', 'groq']
+---
+
+# Transcribe Videos with Sapat in Daytona
+
+# Introduction
+
+Video transcription looks simple until it becomes part of a repeatable developer workflow. One engineer may have `ffmpeg` installed globally, another may be missing Python build tooling, and a third may have API keys configured for a different provider.
+
+Those small environment differences slow down AI teams that need to turn demos, lectures, product walkthroughs, or research recordings into usable text.
+
+[Sapat](https://github.com/nkkko/sapat) is a Python command line tool for [speech-to-text](../definitions/20260510_definition_speech_to_text.md) workflows. It converts video files to MP3 with `ffmpeg`, sends the audio to a transcription provider, and writes the transcript next to the original video.
+
+At the time of writing, the project includes adapters for OpenAI, Groq, and Azure OpenAI. It can process a single video file or every `.mp4` file in a directory.
+
+This guide shows how to run Sapat inside a [Daytona](https://www.daytona.io/) workspace so the setup is reproducible, portable, and easier to hand off to another engineer.
+
+You will create the workspace, configure provider credentials, install the package, run transcriptions, optionally correct transcripts with a chat model, and troubleshoot the most common failure modes.
+
+![Sapat transcription workflow in Daytona](assets/20260510_guide_sapat_transcription_daytona_img1.svg)
+
+## TL;DR
+
+- Sapat turns video files into `.txt` transcripts by converting them to MP3 and sending the audio to OpenAI, Groq, or Azure OpenAI.
+- Daytona keeps Python, `ffmpeg`, credentials, and test media inside one reproducible workspace.
+- Use `sapat ./video.mp4 --api groq` for a single file, or point Sapat at a directory to process all `.mp4` files inside it.
+- Keep `.env` private. Store only `.env.example` in source control.
+- Choose Groq for fast Whisper-style transcription, OpenAI for broad API familiarity, and Azure OpenAI when your organization already standardizes on Azure deployments.
+
+## Prerequisites
+
+You need the following before starting:
+
+- A Daytona account and the Daytona CLI installed locally.
+- Python knowledge at the level of installing packages and running CLI commands.
+- API access to at least one supported transcription provider: OpenAI, Groq, or Azure OpenAI.
+- One short `.mp4` file for testing. Start with a file under a few minutes so iteration is fast.
+- Basic familiarity with environment variables and `.env` files.
+
+Sapat also depends on `ffmpeg`. You can install it manually in the workspace, or add it to the workspace setup so every new workspace receives the same media tooling.
+
+## Step 1: Create the Daytona workspace
+
+Start from the Sapat repository:
+
+```bash
+daytona create https://github.com/nkkko/sapat --code
+```
+
+Open the workspace in your editor when Daytona finishes provisioning it. The repository layout is intentionally small:
+
+```text
+sapat/
+  pyproject.toml
+  README.md
+  src/
+    sapat/
+      script.py
+      transcription/
+        azure.py
+        base.py
+        groq.py
+        openai.py
+```
+
+The important files are:
+
+| File | Purpose |
+| --- | --- |
+| `pyproject.toml` | Defines the `sapat` package, dependencies, and CLI entry point. |
+| `src/sapat/script.py` | Defines the Click command and CLI options. |
+| `src/sapat/transcription/base.py` | Converts video/audio to MP3 and writes transcript output. |
+| `src/sapat/transcription/openai.py` | Sends audio to the OpenAI transcription endpoint. |
+| `src/sapat/transcription/groq.py` | Sends audio to the Groq OpenAI-compatible transcription endpoint. |
+| `src/sapat/transcription/azure.py` | Sends audio to an Azure OpenAI audio deployment. |
+
+## Step 2: Install system and Python dependencies
+
+Inside the Daytona workspace terminal, verify Python first:
+
+```bash
+python --version
+pip --version
+```
+
+Install `ffmpeg` if the base image does not already include it:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y ffmpeg
+ffmpeg -version
+```
+
+Then install Sapat in editable mode:
+
+```bash
+python -m pip install --upgrade pip
+python -m pip install -e .
+```
+
+The editable install is useful during development because changes in `src/sapat` are picked up without rebuilding a wheel. Confirm that the CLI is available:
+
+```bash
+sapat --help
+```
+
+You should see options for `--language`, `--prompt`, `--temperature`, `--quality`, `--correct`, and `--api`.
+
+## Step 3: Configure provider credentials
+
+Create a local `.env` file in the workspace root. Do not commit this file.
+
+```bash
+touch .env
+```
+
+For OpenAI:
+
+```text
+OPENAI_API_KEY=your_openai_api_key_here
+OPENAI_MODEL=whisper-1
+OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
+OPENAI_MODEL_NAME_CHAT=gpt-4o
+```
+
+For Groq:
+
+```text
+GROQCLOUD_API_KEY=your_groq_api_key_here
+GROQCLOUD_MODEL=whisper-large-v3-turbo
+GROQCLOUD_API_ENDPOINT=https://api.groq.com/openai/v1/audio/transcriptions
+GROQCLOUD_MODEL_NAME_CHAT=llama3-8b-8192
+```
+
+For Azure OpenAI:
+
+```text
+AZURE_OPENAI_API_KEY=your_azure_api_key_here
+AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
+AZURE_OPENAI_DEPLOYMENT_NAME_WHISPER=whisper
+AZURE_OPENAI_API_VERSION_WHISPER=2024-06-01
+AZURE_OPENAI_DEPLOYMENT_NAME_CHAT=gpt-4o
+AZURE_OPENAI_API_VERSION_CHAT=2023-03-15-preview
+```
+
+If you are sharing this workspace setup with a team, add a committed `.env.example` with empty values and keep the real `.env` file private. This gives teammates the expected shape without exposing secrets.
+
+## Step 4: Add a test video
+
+Create a working directory for media:
+
+```bash
+mkdir -p media transcripts
+```
+
+Copy a small `.mp4` file into `media/`. For example:
+
+```text
+media/product-demo.mp4
+```
+
+Start with short audio. A one-minute file is enough to confirm credentials, conversion, and transcript output. Longer files are better once you know the provider and workspace are working.
+
+## Step 5: Run a first transcription
+
+Run Sapat with Groq:
+
+```bash
+sapat media/product-demo.mp4 --api groq --quality M --language en
+```
+
+Run the same file with OpenAI:
+
+```bash
+sapat media/product-demo.mp4 --api openai --quality M --language en
+```
+
+Run it with Azure OpenAI:
+
+```bash
+sapat media/product-demo.mp4 --api azure --quality M --language en
+```
+
+Sapat performs three actions:
+
+1. Converts the video to an MP3 file using `ffmpeg`.
+2. Sends the MP3 file to the selected transcription provider.
+3. Writes a `.txt` transcript beside the original input file.
+
+For `media/product-demo.mp4`, the transcript output is:
+
+```text
+media/product-demo.txt
+```
+
+Sapat removes the temporary MP3 after the transcript is saved, which keeps the workspace clean when processing many videos.
+
+## Step 6: Improve accuracy with prompt and language options
+
+The `--language` option tells the model what language to expect:
+
+```bash
+sapat media/product-demo.mp4 --api groq --language en
+```
+
+The `--prompt` option can help the transcription model with product names, acronyms, or domain vocabulary:
+
+```bash
+sapat media/product-demo.mp4 \
+  --api groq \
+  --language en \
+  --prompt "The speaker mentions Daytona, Sapat, ffmpeg, Whisper, Groq, Azure OpenAI, and OpenAI."
+```
+
+The prompt does not replace editing, but it helps when your video contains unusual names that a generic model may spell incorrectly.
+
+## Step 7: Use transcript correction when needed
+
+Sapat includes a `--correct` flag. When enabled, the tool transcribes the audio, then sends the raw transcript to the configured chat model for cleanup:
+
+```bash
+sapat media/product-demo.mp4 --api openai --quality M --language en --correct
+```
+
+Use correction for rough meeting recordings, product demos with specialized terms, or interviews where punctuation matters. Skip correction when you need a raw transcript for auditing, legal review, or direct comparison between providers.
+
+There is one practical detail to know: correction uses the chat model variables for the provider you selected. For OpenAI, configure `OPENAI_MODEL_NAME_CHAT`. For Groq, configure `GROQCLOUD_MODEL_NAME_CHAT`. For Azure OpenAI, configure the chat deployment fields.
+
+## Step 8: Process a folder of videos
+
+If you pass a directory instead of a single file, Sapat processes every `.mp4` file in that directory:
+
+```bash
+sapat media --api groq --quality M --language en
+```
+
+This is useful for:
+
+- Transcribing a batch of short user interviews.
+- Converting multiple product walkthroughs into searchable notes.
+- Preparing text from conference clips before summarization.
+- Creating rough captions for a set of tutorial videos.
+
+For larger batches, run a small sample first. Confirm transcript quality, provider cost, and output naming before processing everything.
+
+## Step 9: Choose the right provider
+
+The best provider depends on your constraints:
+
+| Provider | Good fit | Notes |
+| --- | --- | --- |
+| OpenAI | General-purpose workflows, familiar API conventions, teams already using OpenAI. | Sapat calls the standard audio transcription endpoint configured in `.env`. |
+| Groq | Fast Whisper-style transcription and OpenAI-compatible API patterns. | A good default for quick iteration if your account is already configured. |
+| Azure OpenAI | Enterprise workspaces, Azure governance, or teams with existing Azure deployments. | Requires the correct resource endpoint, deployment names, and API versions. |
+
+If you are writing an internal tool, start with whichever provider your organization already approves. If you are experimenting, run the same short clip through two providers and compare accuracy, punctuation, and cost before committing to a larger batch.
+
+## Step 10: Keep the workflow reproducible
+
+Daytona helps most when the setup is not only running today, but also repeatable next week. A good production-ready Sapat workspace should include:
+
+- A `.env.example` file with every required variable.
+- A short `media/README.md` explaining where test videos should live.
+- A documented provider choice for the team.
+- A `requirements` or package install command that is easy to rerun.
+- A note that `.env`, transcripts, and raw media should not be committed unless the content is public and intentionally shared.
+
+You can also add a workspace setup script:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo apt-get update
+sudo apt-get install -y ffmpeg
+python -m pip install --upgrade pip
+python -m pip install -e .
+sapat --help
+```
+
+Store it as `scripts/setup-workspace.sh`, then run it whenever a new workspace is created.
+
+## Common Issues and Troubleshooting
+
+**Problem:** `ffmpeg: command not found`
+
+**Solution:** Install `ffmpeg` in the Daytona workspace:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y ffmpeg
+```
+
+**Problem:** `sapat: command not found`
+
+**Solution:** Install the package in editable mode from the repository root:
+
+```bash
+python -m pip install -e .
+```
+
+Then restart the terminal or run:
+
+```bash
+python -m sapat.script --help
+```
+
+**Problem:** The provider returns an authentication error.
+
+**Solution:** Check the matching key in `.env`. For example, Groq uses `GROQCLOUD_API_KEY`, while OpenAI uses `OPENAI_API_KEY`. Also verify that `python-dotenv` is installed and that you are running the command from the repository root where `.env` exists.
+
+**Problem:** The audio file is too large.
+
+**Solution:** Sapat validates audio size in the provider adapters. Start by lowering MP3 quality:
+
+```bash
+sapat media/product-demo.mp4 --api openai --quality L
+```
+
+For very long videos, split the input into smaller clips before transcription.
+
+**Problem:** The transcript misses product names.
+
+**Solution:** Use `--prompt` to provide vocabulary:
+
+```bash
+sapat media/demo.mp4 --api groq --prompt "This recording mentions Daytona, Sapat, dev containers, and Azure OpenAI."
+```
+
+**Problem:** A directory run skips files.
+
+**Solution:** Sapat currently looks for `.mp4` files when processing a directory. Confirm the file extension and convert other formats to `.mp4` first, or process those files one at a time after converting them.
+
+## Conclusion
+
+Sapat gives AI engineers a focused transcription pipeline: video in, MP3 conversion through `ffmpeg`, provider transcription, optional correction, and `.txt` output.
+
+Daytona makes that pipeline easier to reproduce by keeping the operating system packages, Python dependencies, API configuration, and test media in one workspace.
+
+The next step is to turn the workflow into a small team template. Add `.env.example`, document your preferred provider, keep sample videos short, and include setup commands in the workspace.
+
+That way, anyone on the team can open the project in Daytona and get from a video file to a usable transcript without debugging local environment differences.
+
+## References
+
+- [Sapat repository](https://github.com/nkkko/sapat)
+- [Daytona](https://www.daytona.io/)
+- [OpenAI audio transcription API](https://platform.openai.com/docs/guides/speech-to-text)
+- [Groq speech-to-text documentation](https://console.groq.com/docs/speech-to-text)
+- [Azure OpenAI audio documentation](https://learn.microsoft.com/azure/ai-services/openai/)
+- [ffmpeg documentation](https://ffmpeg.org/documentation.html)

--- a/guides/20260510_guide_transcribe_videos_with_sapat_and_daytona.md
+++ b/guides/20260510_guide_transcribe_videos_with_sapat_and_daytona.md
@@ -31,6 +31,7 @@ You will create the workspace, configure provider credentials, install the packa
 - Use `sapat ./video.mp4 --api groq` for a single file, or point Sapat at a directory to process all `.mp4` files inside it.
 - Keep `.env` private. Store only `.env.example` in source control.
 - Choose Groq for fast Whisper-style transcription, OpenAI for broad API familiarity, and Azure OpenAI when your organization already standardizes on Azure deployments.
+- Add a small transcript quality gate before handing notes to engineering, support, or product teams.
 
 ## Prerequisites
 
@@ -260,7 +261,89 @@ The best provider depends on your constraints:
 
 If you are writing an internal tool, start with whichever provider your organization already approves. If you are experimenting, run the same short clip through two providers and compare accuracy, punctuation, and cost before committing to a larger batch.
 
-## Step 10: Keep the workflow reproducible
+## Step 10: Add a transcript quality gate
+
+Transcription output is most useful when the team can trust it. Before sharing a transcript as a source of truth, create a short review checklist in the Daytona workspace.
+
+Create a file named `transcripts/quality-checklist.md`:
+
+```markdown
+# Transcript Quality Checklist
+
+- Source file:
+- Provider:
+- Command used:
+- Transcript file:
+- Reviewer:
+- Review date:
+
+## Required checks
+
+- [ ] Speaker names or roles are clear enough for the handoff.
+- [ ] Product names, APIs, and company names are spelled correctly.
+- [ ] Timestamps or section breaks are added for long recordings.
+- [ ] Sensitive information is removed before sharing externally.
+- [ ] Follow-up actions are separated from raw transcript text.
+- [ ] The original media file location is documented.
+```
+
+For product demos, add a short handoff summary above the raw transcript:
+
+```markdown
+# Handoff Summary
+
+## What happened
+
+One paragraph summary of the recording.
+
+## Decisions
+
+- Decision 1
+- Decision 2
+
+## Follow-up tasks
+
+- [ ] Task owner: next action
+- [ ] Task owner: next action
+
+## Open questions
+
+- Question 1
+- Question 2
+```
+
+This step is intentionally separate from Sapat. Sapat creates the transcript; the quality gate turns that transcript into something another engineer can use without replaying the video.
+
+## Step 11: Compare providers with one repeatable clip
+
+If your team has access to more than one provider, run the same short clip through each provider before processing a large folder.
+
+Use commands like these:
+
+```bash
+sapat media/product-demo.mp4 --api openai --quality M --language en
+mv media/product-demo.txt transcripts/product-demo-openai.txt
+
+sapat media/product-demo.mp4 --api groq --quality M --language en
+mv media/product-demo.txt transcripts/product-demo-groq.txt
+
+sapat media/product-demo.mp4 --api azure --quality M --language en
+mv media/product-demo.txt transcripts/product-demo-azure.txt
+```
+
+Then score each transcript:
+
+| Provider | Accuracy | Product terms | Punctuation | Latency | Notes |
+| --- | --- | --- | --- | --- | --- |
+| OpenAI |  |  |  |  |  |
+| Groq |  |  |  |  |  |
+| Azure OpenAI |  |  |  |  |  |
+
+Keep the winning provider and command in your workspace README. That makes later batch work easier to reproduce and gives the team a reason for the provider choice.
+
+One implementation detail matters here: Sapat writes the transcript next to the input file and uses the same basename with a `.txt` extension. Move or rename the transcript after each provider run so the next run does not overwrite the previous result.
+
+## Step 12: Keep the workflow reproducible
 
 Daytona helps most when the setup is not only running today, but also repeatable next week. A good production-ready Sapat workspace should include:
 

--- a/guides/assets/20260510_guide_sapat_transcription_daytona_img1.svg
+++ b/guides/assets/20260510_guide_sapat_transcription_daytona_img1.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="640" viewBox="0 0 1200 640" role="img" aria-labelledby="title desc">
+  <title id="title">Sapat transcription workflow in a Daytona workspace</title>
+  <desc id="desc">A workflow diagram showing a video file entering a Daytona workspace, being converted with ffmpeg, transcribed by Sapat through OpenAI, Groq, or Azure OpenAI, then saved as a text transcript.</desc>
+  <rect width="1200" height="640" fill="#0b1220"/>
+  <rect x="60" y="70" width="1080" height="500" rx="28" fill="#111827" stroke="#2dd4bf" stroke-width="4"/>
+  <text x="600" y="125" text-anchor="middle" fill="#f8fafc" font-family="Arial, sans-serif" font-size="38" font-weight="700">Sapat transcription workflow in Daytona</text>
+  <text x="600" y="164" text-anchor="middle" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="20">Keep media, dependencies, API keys, and transcript outputs inside a reproducible workspace</text>
+
+  <g font-family="Arial, sans-serif">
+    <rect x="105" y="245" width="190" height="120" rx="18" fill="#1e293b" stroke="#60a5fa" stroke-width="3"/>
+    <text x="200" y="292" text-anchor="middle" fill="#eff6ff" font-size="24" font-weight="700">Video files</text>
+    <text x="200" y="326" text-anchor="middle" fill="#bfdbfe" font-size="17">MP4 input</text>
+
+    <path d="M305 305 L390 305" stroke="#94a3b8" stroke-width="5" marker-end="url(#arrow)"/>
+
+    <rect x="400" y="225" width="245" height="160" rx="18" fill="#042f2e" stroke="#2dd4bf" stroke-width="3"/>
+    <text x="522" y="270" text-anchor="middle" fill="#ccfbf1" font-size="24" font-weight="700">Daytona workspace</text>
+    <text x="522" y="307" text-anchor="middle" fill="#99f6e4" font-size="17">Python, Sapat, ffmpeg</text>
+    <text x="522" y="335" text-anchor="middle" fill="#99f6e4" font-size="17">.env provider keys</text>
+
+    <path d="M655 305 L735 305" stroke="#94a3b8" stroke-width="5" marker-end="url(#arrow)"/>
+
+    <rect x="745" y="210" width="205" height="190" rx="18" fill="#312e81" stroke="#a78bfa" stroke-width="3"/>
+    <text x="848" y="258" text-anchor="middle" fill="#ede9fe" font-size="24" font-weight="700">Sapat CLI</text>
+    <text x="848" y="295" text-anchor="middle" fill="#ddd6fe" font-size="17">Convert to MP3</text>
+    <text x="848" y="323" text-anchor="middle" fill="#ddd6fe" font-size="17">Call API</text>
+    <text x="848" y="351" text-anchor="middle" fill="#ddd6fe" font-size="17">Optional correction</text>
+
+    <path d="M960 305 L1040 305" stroke="#94a3b8" stroke-width="5" marker-end="url(#arrow)"/>
+
+    <rect x="1045" y="245" width="120" height="120" rx="18" fill="#422006" stroke="#f59e0b" stroke-width="3"/>
+    <text x="1105" y="292" text-anchor="middle" fill="#fffbeb" font-size="23" font-weight="700">.txt</text>
+    <text x="1105" y="326" text-anchor="middle" fill="#fde68a" font-size="16">Transcript</text>
+
+    <rect x="690" y="450" width="320" height="58" rx="16" fill="#0f172a" stroke="#64748b" stroke-width="2"/>
+    <text x="850" y="486" text-anchor="middle" fill="#e2e8f0" font-size="19">OpenAI, Groq, or Azure OpenAI</text>
+    <path d="M850 410 L850 445" stroke="#94a3b8" stroke-width="4" marker-end="url(#arrow)"/>
+  </g>
+
+  <defs>
+    <marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto" markerUnits="strokeWidth">
+      <path d="M2 2 L10 6 L2 10 Z" fill="#94a3b8"/>
+    </marker>
+  </defs>
+</svg>


### PR DESCRIPTION
## Summary

/claim #13

Adds a long-form guide for using Sapat inside a Daytona workspace to transcribe video files with OpenAI, Groq, or Azure OpenAI.

## Included

- New guide: Transcribe Videos with Sapat in Daytona
- Original workflow diagram asset
- New speech-to-text definition
- First-time contributor author profile

## Validation

- Ran targeted Markdown lint on the new guide, definition, and author profile:
  
px markdownlint guides/20260510_guide_transcribe_videos_with_sapat_and_daytona.md definitions/20260510_definition_speech_to_text.md authors/godd-ctrl.md

Note: repository-wide markdown lint currently reports pre-existing issues in older files, so validation was scoped to files changed by this PR.