### PR TITLE
Build Subtitle-Ready Transcripts with Sapat

### DIFF
--- a/authors/arya_singh.md
+++ b/authors/arya_singh.md
@@ -1,0 +1,2 @@
+Author: Arya Singh Title: Full-Stack Developer Description: Arya is a full-stack developer who builds practical AI and automation workflows for engineering teams. He focuses on reproducible development environments, clear technical writing, and shipping useful tools from idea to working artifact.
+Author Image: [https://github.com/Iineman2.png] Author LinkedIn: Author Twitter: Company Name: Independent Company Description: Independent software development and automation work for practical engineering workflows.

--- a/definitions/20260511_definition_subtitle_ready_transcript.md
+++ b/definitions/20260511_definition_subtitle_ready_transcript.md
@@ -1,0 +1,20 @@
+---
+title: 'Subtitle-Ready Transcript'
+description:
+  'A reviewed transcript prepared for conversion into subtitles, captions, or
+  translated publishing assets.'
+date: 2026-05-11
+author: 'Arya Singh'
+---
+
+# Subtitle-Ready Transcript
+
+## Definition
+
+A subtitle-ready transcript is a cleaned and reviewed transcript that has been prepared for captioning or subtitle production. It preserves the speaker's meaning, fixes obvious transcription mistakes, keeps product names and technical terms consistent, and is segmented into short readable blocks.
+
+## Context and Usage
+
+Subtitle-ready transcripts are useful in accessibility, education, product marketing, developer relations, and documentation workflows. They sit between raw speech-to-text output and final subtitle formats such as SRT or WebVTT.
+
+Teams often review glossary terms, speaker names, privacy-sensitive content, and reading speed before handing the transcript to a timing, translation, or publishing step.

--- a/guides/20260511_build_subtitle_ready_transcripts_with_sapat_and_daytona.md
+++ b/guides/20260511_build_subtitle_ready_transcripts_with_sapat_and_daytona.md
@@ -1,0 +1,410 @@
+---
+title: 'Build Subtitle-Ready Transcripts with Sapat'
+description:
+  'Create a reproducible Daytona workflow for Sapat transcription, correction,
+  subtitle review, and publishing handoff.'
+date: 2026-05-11
+author: 'Arya Singh'
+tags: ['daytona', 'sapat', 'transcription', 'subtitles']
+---
+
+# Build Subtitle-Ready Transcripts with Sapat
+
+# Introduction
+
+Video archives become much more useful when every recording has a clean transcript, a subtitle file, and a clear review trail. Meeting recordings, product walkthroughs, community calls, course videos, and customer demos all contain information that teams need later.
+
+The hard part is not only turning speech into text. The hard part is making the workflow repeatable enough that another engineer can open the same repository, run the same commands, and produce handoff-ready artifacts without guessing which provider, prompt, language setting, or correction step was used.
+
+This guide shows how to use [Sapat](https://github.com/nkkko/sapat), a Python command-line transcription tool, inside a [Daytona workspace](/definitions/20240819_definition_daytona%20workspace.md).
+
+Sapat converts video files to MP3 with `ffmpeg`, sends the audio to OpenAI, Groq, or Azure OpenAI, optionally runs a correction pass, and writes a `.txt` transcript beside the source video.
+
+We will turn that into a practical subtitle delivery workflow for AI engineers: one workspace, one media folder, repeatable provider configuration, transcript review, subtitle segmentation, and a publishing checklist.
+
+The emphasis here is different from a basic "run a transcription command" tutorial. By the end, you will have a workspace pattern that supports multilingual videos, subtitle-ready text, review notes, and clean artifacts that can be handed to content, education, or accessibility teams.
+
+![Sapat subtitle workflow](assets/20260511_build_subtitle_ready_transcripts_with_sapat_and_daytona_img1.svg)
+
+## TL;DR
+
+- Use Daytona to create a reproducible workspace for Sapat instead of configuring transcription tools directly on your laptop.
+- Configure one or more providers: OpenAI, Groq, or Azure OpenAI.
+- Use Sapat's `--language`, `--prompt`, `--temperature`, `--quality`, `--correct`, and `--api` flags to make transcription runs predictable.
+- Convert raw `.txt` transcripts into subtitle-ready review files with speaker, glossary, timing, and publishing notes.
+- Keep input videos, generated transcripts, subtitle drafts, and reviewer notes in separate folders so the workflow can be repeated safely.
+
+## What You Will Build
+
+The final workspace will have a simple structure:
+
+```text
+sapat-subtitle-workflow/
+  .devcontainer/
+    devcontainer.json
+  media/
+    raw/
+    transcripts/
+    subtitles/
+    review/
+  prompts/
+    glossary.txt
+    subtitle-correction.md
+  README.md
+```
+
+Sapat writes transcripts next to the input video by default. The folder layout above gives you a controlled place to move each output after every run.
+
+That matters when a directory contains several `.mp4` files and you want to avoid mixing raw media, generated text, reviewer changes, and publishable drafts.
+
+## Prerequisites
+
+Before starting, make sure you have:
+
+- [Daytona](https://www.daytona.io/docs/installation/installation/) installed.
+- Docker running locally or available through your Daytona target.
+- A GitHub account for creating a small workflow repository.
+- Python 3.6 or newer in the workspace.
+- `ffmpeg` available in the workspace.
+- API credentials for at least one supported provider: OpenAI, Groq, or Azure OpenAI.
+- One or more `.mp4` files that you are allowed to process.
+
+You do not need every provider. Pick the one that matches your budget, quality target, and compliance requirements.
+
+## Step 1: Create a Workspace Repository
+
+Create a new repository for the workflow. You can keep it private if your videos or transcripts are sensitive.
+
+```bash
+mkdir sapat-subtitle-workflow
+cd sapat-subtitle-workflow
+git init
+mkdir -p .devcontainer media/raw media/transcripts media/subtitles media/review prompts
+```
+
+Add a `.devcontainer/devcontainer.json` file so Daytona can open the same environment every time:
+
+```json
+{
+  "name": "sapat-subtitle-workflow",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11",
+  "features": {},
+  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y ffmpeg && python -m pip install --upgrade pip && pip install git+https://github.com/nkkko/sapat.git",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python"
+      ]
+    }
+  }
+}
+```
+
+Commit the initial workspace files:
+
+```bash
+git add .
+git commit -m "Create Sapat subtitle workflow workspace"
+```
+
+Then create the Daytona workspace from the repository:
+
+```bash
+daytona create https://github.com/YOUR_USERNAME/sapat-subtitle-workflow --code
+```
+
+Daytona opens the repository in a clean development environment. The `postCreateCommand` installs `ffmpeg` and Sapat so teammates do not need to repeat the same setup manually.
+
+## Step 2: Add Provider Credentials
+
+Sapat reads provider settings from a `.env` file. Create one in the workspace root:
+
+```bash
+touch .env
+```
+
+For OpenAI, add:
+
+```bash
+OPENAI_API_KEY=your_openai_key
+OPENAI_MODEL=whisper-1
+OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
+OPENAI_MODEL_NAME_CHAT=gpt-4o
+```
+
+For Groq, add:
+
+```bash
+GROQCLOUD_API_KEY=your_groq_key
+GROQCLOUD_MODEL=whisper-large-v3-turbo
+GROQCLOUD_API_ENDPOINT=https://api.groq.com/openai/v1/audio/transcriptions
+GROQCLOUD_MODEL_NAME_CHAT=llama3-8b-8192
+```
+
+For Azure OpenAI, add:
+
+```bash
+AZURE_OPENAI_API_KEY=your_azure_key
+AZURE_OPENAI_ENDPOINT=https://DEPLOYMENTENDPOINTNAME.openai.azure.com
+AZURE_OPENAI_DEPLOYMENT_NAME_WHISPER=whisper
+AZURE_OPENAI_API_VERSION_WHISPER=2024-06-01
+AZURE_OPENAI_DEPLOYMENT_NAME_CHAT=gpt-4o
+AZURE_OPENAI_API_VERSION_CHAT=2023-03-15-preview
+```
+
+Add `.env` to `.gitignore`:
+
+```bash
+echo ".env" >> .gitignore
+```
+
+Keep provider credentials out of Git. For shared workspaces, store the expected variable names in `.env.example` and keep actual keys in your secret manager.
+
+## Step 3: Prepare Media and Prompt Files
+
+Copy a video into `media/raw`:
+
+```bash
+cp ~/Downloads/product-demo-spanish.mp4 media/raw/
+```
+
+Create a glossary file. This helps keep product names, project names, speaker names, and acronyms consistent.
+
+```bash
+cat > prompts/glossary.txt <<'EOF'
+Daytona
+Sapat
+dev container
+workspace
+subtitle
+accessibility
+EOF
+```
+
+Create a correction prompt:
+
+```bash
+cat > prompts/subtitle-correction.md <<'EOF'
+Correct spelling, capitalization, punctuation, and obvious transcription mistakes.
+Preserve the speaker's meaning.
+Keep product names from the glossary exact.
+Do not summarize.
+Prefer short sentences that can be split into subtitles.
+EOF
+```
+
+Sapat accepts `--prompt` as a text string, so for a short run you can paste a compact version of this prompt directly into the command. Keeping the longer prompt in a file is still useful because it documents the editorial rule set used by the team.
+
+## Step 4: Run Your First Transcription
+
+Run Sapat on a single video:
+
+```bash
+sapat media/raw/product-demo-spanish.mp4 \
+  --api groq \
+  --quality H \
+  --language es \
+  --prompt "Product demo with Daytona, Sapat, workspaces, dev containers, and subtitles." \
+  --temperature 0.2 \
+  --correct
+```
+
+Here is what each option does:
+
+| Option | Why it matters |
+| --- | --- |
+| `--api groq` | Selects the provider. Sapat also supports `openai` and `azure`. |
+| `--quality H` | Converts the video to higher-quality MP3 audio before transcription. |
+| `--language es` | Tells the transcription model the expected speech language. |
+| `--prompt` | Biases the model toward your vocabulary and domain words. |
+| `--temperature 0.2` | Keeps output more deterministic than a higher-temperature run. |
+| `--correct` | Runs a correction pass after transcription. |
+
+Sapat creates `media/raw/product-demo-spanish.txt`. Move it into the transcript folder:
+
+```bash
+mv media/raw/product-demo-spanish.txt media/transcripts/product-demo-spanish.transcript.txt
+```
+
+Sapat also creates a temporary MP3 file during processing and deletes it after the transcript is saved. That keeps the workspace clean and avoids accidentally committing derived audio.
+
+## Step 5: Process a Batch of Videos
+
+If you pass a directory, Sapat processes every `.mp4` file in that directory:
+
+```bash
+sapat media/raw \
+  --api openai \
+  --quality M \
+  --language en \
+  --prompt "Engineering demo with terminal commands, Daytona workspaces, Sapat transcription, and subtitles." \
+  --temperature 0 \
+  --correct
+```
+
+After the run, move outputs into the transcript folder:
+
+```bash
+for file in media/raw/*.txt; do
+  name="$(basename "$file" .txt)"
+  mv "$file" "media/transcripts/${name}.transcript.txt"
+done
+```
+
+For repeatable production work, run batches by language or content type. Mixing English webinars, Spanish demos, and noisy customer calls in one run makes troubleshooting harder. Separate runs let you tune `--language`, `--prompt`, and `--quality` without losing track of what produced each transcript.
+
+## Step 6: Convert the Transcript into a Subtitle Draft
+
+Sapat currently writes plain `.txt` transcripts, not `.srt` or `.vtt` subtitle files. Treat its output as the first stage of the subtitle workflow. The next stage is segmentation.
+
+Create a subtitle draft file:
+
+```bash
+cp media/transcripts/product-demo-spanish.transcript.txt \
+  media/subtitles/product-demo-spanish.subtitle-draft.md
+```
+
+Open the draft and split long paragraphs into short caption blocks. A practical first pass is:
+
+- One idea per caption.
+- One or two lines per caption.
+- Fewer than 42 characters per line when possible.
+- Avoid splitting names, commands, or URLs across captions.
+- Keep reading speed comfortable for the target audience.
+
+Example:
+
+```text
+[00:00:04.000 --> 00:00:08.500]
+Welcome to this Daytona workspace.
+We will transcribe a product demo with Sapat.
+
+[00:00:08.500 --> 00:00:13.000]
+The workspace keeps ffmpeg, Python,
+and provider credentials isolated.
+```
+
+If the model did not return timestamps, estimate timestamps during review or run a separate alignment tool later. The important thing at this stage is to produce subtitle-ready text that is short, readable, and easy to align.
+
+## Step 7: Add a Review Checklist
+
+Create a review note beside each subtitle draft:
+
+```bash
+cat > media/review/product-demo-spanish.review.md <<'EOF'
+# Review notes: product-demo-spanish
+
+## Source
+
+- Video: media/raw/product-demo-spanish.mp4
+- Transcript: media/transcripts/product-demo-spanish.transcript.txt
+- Subtitle draft: media/subtitles/product-demo-spanish.subtitle-draft.md
+- Provider: Groq
+- Language: es
+- Quality: H
+- Correction: enabled
+
+## Checks
+
+- [ ] Product names match glossary
+- [ ] Speaker names are correct
+- [ ] Commands and file paths are correct
+- [ ] Captions are short enough to read
+- [ ] No private information remains
+- [ ] Captions are ready for timing alignment
+EOF
+```
+
+This looks simple, but it is the difference between "we generated text" and "we can publish this safely." Review notes also make the workflow auditable. If a teammate asks why one video used Groq and another used Azure OpenAI, the answer is in the artifact folder.
+
+## Step 8: Translate or Localize Carefully
+
+For multilingual publishing, do not translate raw transcripts blindly. First produce the clean source-language transcript, then translate the reviewed subtitle draft. This avoids multiplying transcription errors across languages.
+
+A safe sequence is:
+
+1. Transcribe with the correct source language.
+2. Correct terms using the glossary.
+3. Segment into subtitle-ready blocks.
+4. Review the source-language draft.
+5. Translate the reviewed blocks.
+6. Review the translated version with a native speaker or domain reviewer.
+
+Store translations beside the source draft:
+
+```text
+media/subtitles/
+  product-demo-spanish.subtitle-draft.es.md
+  product-demo-spanish.subtitle-draft.en.md
+```
+
+When you translate, keep the caption block boundaries stable unless the target language needs a different reading rhythm. This makes it easier to reuse timing data.
+
+## Step 9: Troubleshooting
+
+**Problem:** `ffmpeg` is not found.
+
+**Solution:** Confirm the workspace installed it:
+
+```bash
+ffmpeg -version
+```
+
+If it is missing, install it in the dev container:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y ffmpeg
+```
+
+Then add that installation command to `.devcontainer/devcontainer.json` so the fix persists.
+
+**Problem:** Sapat says the provider credentials are missing.
+
+**Solution:** Check that `.env` is in the workspace root and uses the exact variable names expected by Sapat. For example, Groq requires `GROQCLOUD_API_KEY`, `GROQCLOUD_MODEL`, `GROQCLOUD_API_ENDPOINT`, and `GROQCLOUD_MODEL_NAME_CHAT`.
+
+**Problem:** The transcript contains product-name mistakes.
+
+**Solution:** Add the correct names to your `--prompt` and to `prompts/glossary.txt`. Re-run with `--correct`, then compare the corrected transcript against the original.
+
+**Problem:** Large files fail.
+
+**Solution:** The OpenAI and Groq implementations in Sapat validate audio file size against a 25 MB limit after conversion. Lower the MP3 quality with `--quality M` or `--quality L`, split the source video, or process shorter clips.
+
+**Problem:** Directory processing skips files.
+
+**Solution:** Sapat's directory mode processes `.mp4` files. Convert or rename other video formats before the batch run, or process them one by one after converting to `.mp4`.
+
+## Step 10: Publishing Handoff
+
+Before handing the files to a publishing team, commit only the workflow files and non-sensitive notes. Avoid committing proprietary video files or transcripts unless the repository is private and approved for that content.
+
+Use this final handoff checklist:
+
+- `media/raw` contains only approved source videos.
+- `media/transcripts` contains raw or corrected `.txt` outputs.
+- `media/subtitles` contains subtitle-ready drafts split into readable blocks.
+- `media/review` records provider, language, quality, and correction settings.
+- `.env` is ignored.
+- `.env.example` documents required provider variables.
+- The glossary is updated with product and speaker names.
+
+The result is a reusable transcription pipeline rather than a one-off AI run. Daytona provides the stable workspace, Sapat handles provider-backed transcription, and your review folders turn generated text into publishable subtitle assets.
+
+## Conclusion
+
+Sapat is a small tool, but it becomes much more useful when you put it inside a reproducible Daytona workflow. The CLI gives you practical controls over provider choice, language, prompt, temperature, audio quality, directory processing, and correction.
+
+Daytona makes those controls repeatable for every teammate who opens the workspace.
+
+For AI engineers, this pattern is a solid base for accessibility and content pipelines. Start with one video, review the transcript carefully, split it into subtitle-ready blocks, and preserve the run details.
+
+Once that works, batch the same workflow across demos, lectures, product videos, and multilingual publishing queues.
+
+## References
+
+- [Sapat GitHub repository](https://github.com/nkkko/sapat)
+- [Daytona documentation](https://www.daytona.io/docs)
+- [OpenAI audio transcription API](https://platform.openai.com/docs/guides/speech-to-text)
+- [Groq audio transcription docs](https://console.groq.com/docs/speech-to-text)
+- [Azure OpenAI audio concepts](https://learn.microsoft.com/azure/ai-services/openai/)

--- a/guides/20260511_build_subtitle_ready_transcripts_with_sapat_and_daytona.md
+++ b/guides/20260511_build_subtitle_ready_transcripts_with_sapat_and_daytona.md
@@ -57,6 +57,32 @@ Sapat writes transcripts next to the input video by default. The folder layout a
 
 That matters when a directory contains several `.mp4` files and you want to avoid mixing raw media, generated text, reviewer changes, and publishable drafts.
 
+## How Sapat Provider Support Is Organized
+
+Sapat keeps provider integrations small and easy to inspect. The CLI entrypoint
+is `src/sapat/script.py`, and each transcription backend lives in
+`src/sapat/transcription`.
+
+At the time of writing, Sapat includes providers for OpenAI, Groq, and Azure
+OpenAI. Each provider implements the same base shape:
+
+- Read provider-specific credentials and model names from `.env`.
+- Validate or prepare the converted audio file.
+- Send the MP3 file to the provider's speech-to-text endpoint.
+- Return either JSON or text that Sapat can save as a `.txt` transcript.
+- Optionally use a chat model to run a correction pass.
+
+That structure is useful when you want to add another speech-to-text API later.
+A new provider should follow the existing `TranscriptionBase` contract, add its
+environment variables to `.env.example`, and then register a new `--api` choice
+in the CLI.
+
+For a subtitle workflow, the important provider capability to look for is not
+only transcription quality. Check whether the provider can return timestamps,
+word-level metadata, stable language controls, and a predictable response
+format. Those features decide how much manual work remains between a raw
+transcript and a timed subtitle file.
+
 ## Prerequisites
 
 Before starting, make sure you have:
@@ -87,7 +113,7 @@ Add a `.devcontainer/devcontainer.json` file so Daytona can open the same enviro
 ```json
 {
   "name": "sapat-subtitle-workflow",
-  "image": "mcr.microsoft.com/devcontainers/python:3.11",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bullseye",
   "features": {},
   "postCreateCommand": "sudo apt-get update && sudo apt-get install -y ffmpeg && python -m pip install --upgrade pip && pip install git+https://github.com/nkkko/sapat.git",
   "customizations": {

--- a/guides/assets/20260511_build_subtitle_ready_transcripts_with_sapat_and_daytona_img1.svg
+++ b/guides/assets/20260511_build_subtitle_ready_transcripts_with_sapat_and_daytona_img1.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="620" viewBox="0 0 1200 620" role="img" aria-labelledby="title desc">
+  <title id="title">Sapat subtitle workflow in Daytona</title>
+  <desc id="desc">A workflow showing video files moving through Daytona, Sapat, provider transcription, correction, subtitle review, and publishing handoff.</desc>
+  <rect width="1200" height="620" fill="#f7f8fb"/>
+  <rect x="70" y="80" width="1060" height="460" rx="24" fill="#ffffff" stroke="#d7dce6" stroke-width="3"/>
+  <text x="90" y="132" font-family="Arial, sans-serif" font-size="34" font-weight="700" fill="#111827">Subtitle delivery workflow</text>
+  <text x="90" y="166" font-family="Arial, sans-serif" font-size="18" fill="#4b5563">Reproducible transcription, correction, review, and publishing handoff inside a Daytona workspace</text>
+  <g font-family="Arial, sans-serif">
+    <rect x="100" y="235" width="150" height="120" rx="14" fill="#e8f0ff" stroke="#7895d8" stroke-width="2"/>
+    <text x="132" y="284" font-size="22" font-weight="700" fill="#193766">MP4 videos</text>
+    <text x="126" y="318" font-size="16" fill="#31527c">media/raw</text>
+    <rect x="300" y="235" width="150" height="120" rx="14" fill="#edf8f2" stroke="#74b38a" stroke-width="2"/>
+    <text x="334" y="274" font-size="22" font-weight="700" fill="#155d35">Daytona</text>
+    <text x="325" y="307" font-size="16" fill="#246044">workspace</text>
+    <text x="328" y="331" font-size="16" fill="#246044">ffmpeg + Python</text>
+    <rect x="500" y="235" width="150" height="120" rx="14" fill="#fff4e5" stroke="#d99d38" stroke-width="2"/>
+    <text x="552" y="274" font-size="22" font-weight="700" fill="#7a4b00">Sapat</text>
+    <text x="535" y="307" font-size="16" fill="#6a4d18">quality, prompt,</text>
+    <text x="542" y="331" font-size="16" fill="#6a4d18">language, API</text>
+    <rect x="700" y="235" width="150" height="120" rx="14" fill="#f3ecff" stroke="#a181d6" stroke-width="2"/>
+    <text x="728" y="274" font-size="22" font-weight="700" fill="#4b267a">Provider</text>
+    <text x="718" y="307" font-size="16" fill="#573783">OpenAI, Groq,</text>
+    <text x="732" y="331" font-size="16" fill="#573783">or Azure</text>
+    <rect x="900" y="235" width="150" height="120" rx="14" fill="#e7f8fb" stroke="#66adc1" stroke-width="2"/>
+    <text x="935" y="274" font-size="22" font-weight="700" fill="#105061">Transcript</text>
+    <text x="928" y="307" font-size="16" fill="#2b6270">corrected txt</text>
+    <text x="932" y="331" font-size="16" fill="#2b6270">plus review</text>
+    <path d="M255 295 H292" stroke="#606b80" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
+    <path d="M455 295 H492" stroke="#606b80" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
+    <path d="M655 295 H692" stroke="#606b80" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
+    <path d="M855 295 H892" stroke="#606b80" stroke-width="4" fill="none" marker-end="url(#arrow)"/>
+    <rect x="235" y="405" width="730" height="76" rx="16" fill="#111827"/>
+    <text x="274" y="438" font-size="20" font-weight="700" fill="#ffffff">Subtitle-ready handoff</text>
+    <text x="274" y="463" font-size="16" fill="#d1d5db">caption blocks, glossary checks, translation notes, accessibility review, and publishable artifacts</text>
+  </g>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#606b80"/>
+    </marker>
+  </defs>
+</svg>


### PR DESCRIPTION
﻿/claim #13

## Summary
- Add a distinct long-form guide for building a subtitle-ready transcription workflow with Sapat inside a Daytona workspace.
- Cover provider setup for OpenAI, Groq, and Azure OpenAI, plus Sapat flags for language, prompt, temperature, quality, correction, and directory processing.
- Add an original workflow SVG, a new subtitle-ready transcript definition, and a first-time contributor author profile.

## Demo video
- Short proof video: https://github.com/Iineman2/content/releases/download/daytona-content-pr175-demo/daytona-content-pr175-sapat-guide-demo.mp4
- Walks through the content-only Sapat subtitle workflow guide, SVG, definition, lint, and DCO evidence.

## Verification
- npm run lint:md -- guides/20260511_build_subtitle_ready_transcripts_with_sapat_and_daytona.md definitions/20260511_definition_subtitle_ready_transcript.md authors/arya_singh.md
- git diff --check HEAD~1 HEAD

## Notes
This article is intentionally scoped away from the active generic setup, provider comparison, redaction, QA, and knowledge-base PRs. It focuses on subtitle-ready artifacts, translation handoff, accessibility review, and publishing pipelines for AI engineers.
