### PR TITLE
Transcribe with Hugging Face in Daytona

### DIFF
--- a/authors/manuel_sampedro.md
+++ b/authors/manuel_sampedro.md
@@ -1,0 +1,8 @@
+Author: Manuel Sampedro
+Title: Independent Developer
+Description: Manuel Sampedro builds practical automation, developer tooling, and AI-assisted workflows with an emphasis on small, reproducible systems that can be tested and maintained by working teams.
+Company Name: Independent
+Company Description: Independent software and automation work.
+Author Image: <https://avatars.githubusercontent.com/u/202281585?v=4>
+Company Logo Dark:
+Company Logo White:

--- a/definitions/20260519_definition_hugging_face_inference_api.md
+++ b/definitions/20260519_definition_hugging_face_inference_api.md
@@ -1,0 +1,25 @@
+---
+title: 'Hugging Face Inference API'
+description: 'A hosted API for running machine learning models from the Hugging Face ecosystem.'
+date: 2026-05-19
+author: 'Manuel Sampedro'
+---
+
+# Hugging Face Inference API
+
+## Definition
+
+The Hugging Face Inference API is a hosted interface for running machine
+learning models through authenticated HTTP requests. Developers use it to call
+tasks such as automatic speech recognition, text generation, embeddings, image
+classification, and other model-backed workflows without operating the model
+infrastructure themselves.
+
+## Context and Usage
+
+In a Daytona workspace, the Hugging Face Inference API is useful when an
+application needs a reproducible development environment plus access to a
+managed model endpoint. Secrets such as access tokens should stay in local
+workspace environment variables, while the application code should keep model
+IDs, request construction, retry behavior, and output parsing under version
+control.

--- a/guides/20260519_transcribe_with_hugging_face_in_daytona.md
+++ b/guides/20260519_transcribe_with_hugging_face_in_daytona.md
@@ -1,0 +1,346 @@
+---
+title: "Transcribe with Hugging Face in Daytona"
+description: "Add and run a Hugging Face-backed Sapat transcription workflow in a reproducible Daytona workspace."
+date: 2026-05-19
+author: "Manuel Sampedro"
+tags: ["daytona", "sapat", "hugging-face", "transcription"]
+---
+
+# Transcribe with Hugging Face in Daytona
+
+# Introduction
+
+AI transcription tools are most useful when the workflow is repeatable. A team
+should be able to open a clean workspace, install the same dependencies, provide
+provider credentials safely, run the same command against a recording, and
+review the same output artifact. That is exactly where Daytona helps: it gives
+you an isolated sandbox for the project instead of asking every developer to
+rebuild the transcription environment on their laptop.
+
+This guide shows how to run Sapat with a Hugging Face transcription provider
+inside a Daytona sandbox. Sapat already handles the boring but important part of
+the workflow: it converts input videos to MP3 with `ffmpeg`, sends the audio to
+the selected transcription service, and writes the transcript beside the source
+file. The companion Sapat pull request adds a small `huggingface` provider so
+AI engineers can use a Hugging Face automatic speech recognition model through
+the same CLI path as the existing OpenAI, Groq, and Azure providers.
+
+The workflow is intentionally conservative. Secrets stay in `.env`, the
+provider change is covered by mocked tests, and the guide uses a Daytona
+sandbox so the setup is disposable. You can use the companion branch while the
+provider pull request is under review, then switch to upstream `main` after it
+is merged.
+
+## TL;DR
+
+- Create a Daytona sandbox and clone the Sapat branch that adds
+  `--api huggingface`.
+- Store the Hugging Face token in `.env`, never in Git.
+- Install Sapat in a Python virtual environment and confirm the CLI exposes the
+  new provider.
+- Run a video file through Sapat and review the generated `.txt` transcript.
+- Use targeted tests before changing provider code or model configuration.
+
+## What You Will Build
+
+The setup has four moving parts: Daytona, Sapat, `ffmpeg`, and the
+[Hugging Face Inference API](/definitions/20260519_definition_hugging_face_inference_api.md).
+Daytona provides the sandbox, Sapat owns the transcription command, `ffmpeg`
+normalizes the input media, and Hugging Face runs the speech-to-text model.
+
+![Sapat Hugging Face workflow in Daytona](assets/20260519_transcribe_with_hugging_face_in_daytona_img1.svg)
+
+The companion implementation lives in
+[nibzard/sapat pull request #19](https://github.com/nibzard/sapat/pull/19).
+It adds a `HuggingFaceTranscription` class, wires `huggingface` into Sapat's
+`--api` option, documents the required environment variables, and adds unit
+tests for request construction and error handling.
+
+## Prerequisites
+
+Before you start, make sure you have:
+
+- The [Daytona CLI](https://www.daytona.io/docs/en/tools/cli/) installed and
+  authenticated.
+- A GitHub account that can clone public repositories.
+- A Hugging Face access token with permission to call inference providers or
+  your own dedicated Hugging Face endpoint.
+- A short `.mp4`, `.mov`, or other video file you are allowed to transcribe.
+- Basic comfort with Python virtual environments.
+
+Do not paste production secrets into shell history shared with other users. For
+team workflows, use your normal secret manager or Daytona environment handling
+instead of committing a `.env` file.
+
+## Step 1: Create a Daytona Sandbox
+
+Create a small sandbox for the transcription work:
+
+```bash
+daytona create --name sapat-hf --class small
+```
+
+Open a shell inside the sandbox:
+
+```bash
+daytona ssh sapat-hf
+```
+
+Clone the companion Sapat branch. While the provider pull request is still
+pending, use the fork and branch directly:
+
+```bash
+git clone https://github.com/manuelsampedro1/sapat.git
+cd sapat
+git checkout codex/huggingface-transcription-provider
+```
+
+After the provider is merged upstream, you can replace the clone URL with
+`https://github.com/nibzard/sapat.git` and use the default branch instead.
+
+## Step 2: Install System and Python Dependencies
+
+Sapat uses `ffmpeg` to convert the source video to MP3 before sending audio to
+the provider. Install it inside the sandbox:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y ffmpeg
+```
+
+Create and activate a Python virtual environment:
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install --upgrade pip setuptools wheel
+python -m pip install -e .
+```
+
+Now confirm that the CLI sees the new provider:
+
+```bash
+python -m sapat.script --help
+```
+
+The `--api` option should include `huggingface` alongside `openai`, `groq`, and
+`azure`. That check is cheap and catches the most common wiring mistake before
+you spend any provider credits.
+
+## Step 3: Configure Hugging Face Without Committing Secrets
+
+Create a local `.env` file for the sandbox:
+
+```bash
+printf '%s\n' \
+  'HUGGINGFACE_API_KEY=hf_your_token_here' \
+  'HUGGINGFACE_MODEL=openai/whisper-large-v3-turbo' \
+  'HUGGINGFACE_API_ENDPOINT=' \
+  > .env
+```
+
+`HUGGINGFACE_API_KEY` is required. `HUGGINGFACE_MODEL` defaults to
+`openai/whisper-large-v3-turbo` in the companion provider, but keeping it in
+`.env` makes experiments explicit. `HUGGINGFACE_API_ENDPOINT` is optional and
+is useful when you run a dedicated Inference Endpoint rather than a model route
+on the shared API.
+
+The provider sends raw audio bytes to Hugging Face and expects either a JSON
+response with a `text` field or plain text. This follows the automatic speech
+recognition API shape documented by Hugging Face, where raw audio payloads are
+accepted when no additional parameters are required.
+
+## Step 4: Validate the Provider Before Using a Real Recording
+
+Run the unit tests added with the provider:
+
+```bash
+python -m unittest discover -s tests
+```
+
+The tests mock the outbound request, so they do not call Hugging Face and do
+not require a real token. They verify that Sapat:
+
+- Requires `HUGGINGFACE_API_KEY` before making a request.
+- Builds the model endpoint from `HUGGINGFACE_MODEL`.
+- Respects `HUGGINGFACE_API_ENDPOINT` when you provide a dedicated endpoint.
+- Sends the correct audio `Content-Type` for supported file extensions.
+
+You should also run:
+
+```bash
+git diff --check
+```
+
+That catches whitespace issues before you turn the sandbox into a repeatable
+workflow for teammates.
+
+## Step 5: Transcribe a Sample Video
+
+Create a folder for local media and copy a short test video into it:
+
+```bash
+mkdir -p media
+```
+
+Upload or copy your allowed sample video to `media/demo.mp4`. Then run Sapat
+with the Hugging Face provider:
+
+```bash
+sapat media/demo.mp4 --api huggingface --quality M --language en --temperature 0.0
+```
+
+Sapat converts `media/demo.mp4` to `media/demo.mp3`, sends the MP3 file to
+Hugging Face, writes the transcript to `media/demo.txt`, and removes the
+temporary MP3 file when it finishes.
+
+Open the transcript:
+
+```bash
+sed -n '1,120p' media/demo.txt
+```
+
+For longer recordings, start with one short clip before running a whole
+directory. That keeps provider costs predictable and gives you a quick signal
+on model quality.
+
+## Step 6: Batch a Small Folder Safely
+
+Sapat also accepts a directory and processes each `.mp4` file inside it:
+
+```bash
+sapat media --api huggingface --quality M --language en --temperature 0.0
+```
+
+Use this only after the single-file test succeeds. A simple folder structure
+keeps the output easy to review:
+
+```text
+media/
+  demo-001.mp4
+  demo-001.txt
+  demo-002.mp4
+  demo-002.txt
+```
+
+If you are processing meeting or demo recordings, keep a small manifest in the
+workspace:
+
+```markdown
+| File | Source | Permission | Expected Language | Notes |
+| --- | --- | --- | --- | --- |
+| demo-001.mp4 | Product demo | Internal recording | English | Speaker names matter |
+```
+
+The manifest is not required by Sapat, but it helps reviewers understand where
+each transcript came from and whether it can be shared.
+
+## Step 7: Know the Current Limits
+
+The Hugging Face provider in the companion PR is deliberately small. It focuses
+on transcription, endpoint configuration, content type handling, and transcript
+parsing. It does not implement Sapat's optional `--correct` pass. In the
+current Sapat base class, `--correct` calls a separate correction method, and
+providers must implement that method themselves.
+
+For now, run the Hugging Face command without `--correct`. If you need a
+post-processing pass, keep that as a separate step so the transcription
+provider remains easy to test:
+
+```bash
+cp media/demo.txt media/demo.review.txt
+```
+
+Then use your normal review tool or LLM workflow to clean punctuation, speaker
+names, and product names. Keeping the correction step separate also makes it
+easier to compare raw transcript quality across models.
+
+## Troubleshooting
+
+**Problem:** `--api huggingface` is not listed in `python -m sapat.script --help`.
+
+**Solution:** Check that you are on the companion branch:
+
+```bash
+git branch --show-current
+```
+
+If it is not `codex/huggingface-transcription-provider`, switch branches and
+reinstall the package in editable mode:
+
+```bash
+git checkout codex/huggingface-transcription-provider
+python -m pip install -e .
+```
+
+**Problem:** Sapat raises `HUGGINGFACE_API_KEY must be set`.
+
+**Solution:** Confirm `.env` exists in the repository root and contains a real
+token. If you prefer shell exports, set the variable before running Sapat:
+
+```bash
+export HUGGINGFACE_API_KEY=hf_your_token_here
+```
+
+**Problem:** Hugging Face returns a provider or model error.
+
+**Solution:** Confirm that the model supports automatic speech recognition for
+your account and provider. If you use a dedicated endpoint, set
+`HUGGINGFACE_API_ENDPOINT` to that endpoint URL and keep `HUGGINGFACE_MODEL` as
+documentation for the selected model.
+
+**Problem:** `ffmpeg` fails before the provider call.
+
+**Solution:** Run `ffmpeg -version` inside the Daytona sandbox. If it is
+missing, install it with `sudo apt-get install -y ffmpeg`. If the file is
+corrupt or unsupported, try a short known-good MP4 first.
+
+**Problem:** The transcript is empty or lower quality than expected.
+
+**Solution:** Test a shorter clip with clearer audio, set `--quality H`, and
+compare another ASR-capable Hugging Face model. Keep the first run small so you
+can separate model quality from setup mistakes.
+
+## Production Notes for AI Engineers
+
+For a team workflow, do not treat this as a one-off command. Treat it as a
+repeatable development environment:
+
+- Keep provider credentials in the sandbox environment or a secret manager.
+- Keep provider code, tests, and README examples in Git.
+- Run the mocked tests before changing request behavior.
+- Start every new model with a short smoke clip.
+- Save raw transcripts separately from edited transcripts.
+- Record which model and endpoint produced each transcript.
+
+That last point matters. Transcription quality can change when you switch
+models, providers, endpoints, or audio quality settings. A small note in your
+manifest is usually enough:
+
+```markdown
+Model: openai/whisper-large-v3-turbo
+Provider path: Hugging Face Inference API
+Sapat branch: codex/huggingface-transcription-provider
+Quality: M
+Language hint: en
+```
+
+## Conclusion
+
+You now have a Daytona sandbox that can run Sapat with a Hugging Face-backed
+transcription provider. The important part is not just the provider option; it
+is the repeatable workflow around it. The sandbox contains the same source
+branch, the same dependency setup, the same validation commands, and the same
+artifact layout every time you run it.
+
+Once the companion provider PR is merged, the same guide works from upstream
+Sapat with fewer branch-specific steps. Until then, the forked branch gives you
+a concrete, reviewable implementation that can be tested without exposing
+secrets or calling external services during unit tests.
+
+## References
+
+- [Companion Sapat provider pull request](https://github.com/nibzard/sapat/pull/19)
+- [Hugging Face automatic speech recognition API documentation](https://huggingface.co/docs/api-inference/en/tasks/automatic-speech-recognition)
+- [Hugging Face HF Inference provider documentation](https://huggingface.co/docs/inference-providers/en/providers/hf-inference)
+- [Daytona CLI documentation](https://www.daytona.io/docs/en/tools/cli/)

--- a/guides/assets/20260519_transcribe_with_hugging_face_in_daytona_img1.svg
+++ b/guides/assets/20260519_transcribe_with_hugging_face_in_daytona_img1.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">Sapat Hugging Face transcription workflow in Daytona</title>
+  <desc id="desc">A workflow showing a Daytona sandbox running Sapat, sending audio to Hugging Face, and writing a transcript artifact.</desc>
+  <rect width="1200" height="675" fill="#f7f8fb"/>
+  <rect x="70" y="78" width="1060" height="520" rx="24" fill="#ffffff" stroke="#d8deea" stroke-width="2"/>
+  <text x="100" y="132" font-family="Inter, Arial, sans-serif" font-size="34" font-weight="700" fill="#151923">Repeatable transcription workspace</text>
+  <text x="100" y="168" font-family="Inter, Arial, sans-serif" font-size="18" fill="#4a5568">Daytona keeps the tools, provider configuration, validation commands, and output files in one disposable sandbox.</text>
+
+  <rect x="110" y="235" width="210" height="142" rx="18" fill="#eaf2ff" stroke="#9fbdf2" stroke-width="2"/>
+  <text x="140" y="290" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#16213b">Daytona</text>
+  <text x="140" y="322" font-family="Inter, Arial, sans-serif" font-size="16" fill="#344054">Create sandbox</text>
+  <text x="140" y="350" font-family="Inter, Arial, sans-serif" font-size="16" fill="#344054">Clone Sapat branch</text>
+
+  <path d="M340 306H448" stroke="#667085" stroke-width="4" stroke-linecap="round"/>
+  <path d="M448 306L430 294V318Z" fill="#667085"/>
+
+  <rect x="470" y="215" width="260" height="182" rx="18" fill="#ecfdf3" stroke="#86d49b" stroke-width="2"/>
+  <text x="505" y="270" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#122c1c">Sapat CLI</text>
+  <text x="505" y="302" font-family="Inter, Arial, sans-serif" font-size="16" fill="#344054">ffmpeg converts video</text>
+  <text x="505" y="330" font-family="Inter, Arial, sans-serif" font-size="16" fill="#344054">--api huggingface</text>
+  <text x="505" y="358" font-family="Inter, Arial, sans-serif" font-size="16" fill="#344054">Unit-tested request path</text>
+
+  <path d="M750 306H858" stroke="#667085" stroke-width="4" stroke-linecap="round"/>
+  <path d="M858 306L840 294V318Z" fill="#667085"/>
+
+  <rect x="880" y="235" width="210" height="142" rx="18" fill="#fff7ed" stroke="#f2b36d" stroke-width="2"/>
+  <text x="910" y="290" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#4b2600">Hugging Face</text>
+  <text x="910" y="322" font-family="Inter, Arial, sans-serif" font-size="16" fill="#344054">ASR model endpoint</text>
+  <text x="910" y="350" font-family="Inter, Arial, sans-serif" font-size="16" fill="#344054">Returns transcript text</text>
+
+  <path d="M985 400V475H595" stroke="#667085" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M595 475L613 463V487Z" fill="#667085"/>
+
+  <rect x="390" y="438" width="210" height="110" rx="18" fill="#f4f3ff" stroke="#b8b1f0" stroke-width="2"/>
+  <text x="425" y="488" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="700" fill="#26204f">Transcript</text>
+  <text x="425" y="520" font-family="Inter, Arial, sans-serif" font-size="16" fill="#344054">Same-name .txt file</text>
+
+  <rect x="100" y="520" width="220" height="44" rx="10" fill="#151923"/>
+  <text x="122" y="548" font-family="Inter, Arial, sans-serif" font-size="16" fill="#ffffff">No secrets committed</text>
+  <rect x="640" y="520" width="230" height="44" rx="10" fill="#151923"/>
+  <text x="662" y="548" font-family="Inter, Arial, sans-serif" font-size="16" fill="#ffffff">Validation before provider use</text>
+</svg>


### PR DESCRIPTION
/claim #13

## Summary
- add a long-form guide for running Sapat with a Hugging Face transcription provider inside a Daytona sandbox
- add a companion Hugging Face Inference API definition
- add an author profile and original workflow SVG
- link the companion Sapat implementation PR: https://github.com/nibzard/sapat/pull/19

## Writer's checklist
- [x] Uses repository guide frontmatter and naming conventions
- [x] Includes multiple H2 sections, prerequisites, steps, troubleshooting, and references
- [x] Includes a visual asset in guides/assets
- [x] Adds a new definition entry
- [x] Keeps secrets out of the article and uses placeholder tokens only

## Validation
- npx markdownlint guides/20260519_transcribe_with_hugging_face_in_daytona.md definitions/20260519_definition_hugging_face_inference_api.md authors/manuel_sampedro.md
- git diff --check

Targeted markdownlint passed for the changed markdown files. Full repo lint currently fails on pre-existing markdown issues in older files such as articles/20241212_Prebuilds_in_Daytona.md, definitions/20240819_definition_embedding.md, and several older guides; none of those failures are from this PR.

## Companion Sapat validation
- .venv/bin/python -m unittest discover -s tests
- .venv/bin/python -m sapat.script --help
- git diff --check