### PR TITLE
Run Privacy-First AI Transcription With Sapat

### DIFF
--- a/authors/assets/images/daniel-romero-sanchez.svg
+++ b/authors/assets/images/daniel-romero-sanchez.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Daniel Romero Sanchez avatar</title>
+  <desc id="desc">A simple geometric avatar with the initials DRS.</desc>
+  <rect width="512" height="512" rx="96" fill="#0f172a"/>
+  <circle cx="372" cy="132" r="58" fill="#38bdf8" opacity="0.9"/>
+  <circle cx="144" cy="380" r="86" fill="#22c55e" opacity="0.85"/>
+  <path d="M108 166c0-35 28-63 63-63h170c35 0 63 28 63 63v180c0 35-28 63-63 63H171c-35 0-63-28-63-63V166Z" fill="#f8fafc"/>
+  <text x="256" y="281" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="112" font-weight="700" fill="#0f172a">DRS</text>
+</svg>

--- a/authors/daniel-romero-sanchez.md
+++ b/authors/daniel-romero-sanchez.md
@@ -1,0 +1,8 @@
+Author: Daniel Romero Sanchez
+Title: Software Developer
+Description: Daniel Romero Sanchez is a software developer focused on practical automation, web applications, API integrations, and developer workflows. He enjoys turning ambiguous technical tasks into documented, reproducible systems that teams can run and improve.
+Company Name:
+Company Description:
+Author Image: /assets/images/daniel-romero-sanchez.svg
+Company Logo Dark:
+Company Logo White:

--- a/definitions/20260520_definition_transcript_redaction.md
+++ b/definitions/20260520_definition_transcript_redaction.md
@@ -1,0 +1,22 @@
+---
+title: "Transcript Redaction"
+description: "The process of removing or masking sensitive details from speech-to-text output before the text is shared or indexed."
+date: 2026-05-20
+author: "Daniel Romero Sanchez"
+---
+
+# Transcript Redaction
+
+## Definition
+
+Transcript redaction is the process of removing, masking, or replacing sensitive
+details from speech-to-text output before the transcript is shared, indexed,
+summarized, or used by another system.
+
+## Context and Usage
+
+Transcript redaction is common in support, sales, healthcare, legal, finance,
+and internal operations workflows where recordings can include email addresses,
+phone numbers, account identifiers, access tokens, payment details, or personal
+names. A redaction step helps teams keep raw recordings and raw transcripts
+inside a controlled workspace while allowing safer downstream use of the text.

--- a/guides/20260520_guide_privacy_first_sapat_transcription.md
+++ b/guides/20260520_guide_privacy_first_sapat_transcription.md
@@ -1,0 +1,393 @@
+---
+title: "Run Privacy-First AI Transcription With Sapat"
+description: "Use Daytona and Sapat to transcribe recordings, review transcripts, and redact sensitive data before sharing text downstream."
+date: 2026-05-20
+author: "Daniel Romero Sanchez"
+tags: ["daytona", "sapat", "transcription", "privacy", "ai"]
+---
+
+# Run Privacy-First AI Transcription With Sapat
+
+## Introduction
+
+AI transcription is useful because it turns recordings into searchable,
+summarizable text. It is also risky because recordings often contain details
+that were never meant to leave the team that captured them: phone numbers,
+customer names, email addresses, account identifiers, ticket references, access
+tokens spoken aloud during debugging, or internal project names.
+
+This guide shows a practical workflow for running
+[`nkkko/sapat`](https://github.com/nkkko/sapat) inside a reproducible
+[Daytona workspace](</definitions/20240819_definition_daytona workspace.md>)
+while keeping privacy controls close to the source files. You will create a
+workspace, configure one transcription provider, run Sapat against a controlled
+recording, review the transcript, apply a local
+[transcript redaction](</definitions/20260520_definition_transcript_redaction.md>)
+step, and export only the redacted text.
+
+The goal is not to build a full compliance system. The goal is a simple
+engineering loop that helps teams avoid the most common mistake in AI
+transcription projects: treating raw transcripts as safe just because they are
+plain text.
+
+## TL;DR
+
+- **Run Sapat inside Daytona** so the transcription workflow is repeatable.
+- **Keep secrets in `.env`** and keep `.env`, recordings, and raw transcripts out of Git.
+- **Use one provider per run** with Sapat's `--api openai`, `--api groq`, or `--api azure` option.
+- **Review raw transcripts locally** before summarizing, indexing, or sharing them.
+- **Redact common sensitive values** into a separate output file and move only that reviewed file downstream.
+
+## What Sapat Does in This Workflow
+
+Sapat is a Python command-line tool for transcribing video files with Azure
+OpenAI, Groq, or OpenAI. Its current CLI accepts either a single file or a
+directory. When you pass a directory, it processes the `.mp4` files in that
+directory. For each recording, Sapat uses `ffmpeg` to create a temporary MP3,
+sends that MP3 to the selected transcription provider, writes a `.txt` file
+beside the original recording, and then removes the temporary MP3.
+
+That shape is helpful for a privacy-first workflow:
+
+| Stage | What happens | Privacy control |
+| --- | --- | --- |
+| Source recording | The `.mp4` file stays in the workspace | Do not commit recordings |
+| Temporary audio | Sapat creates an MP3 for provider upload | Confirm provider and file size before the run |
+| Raw transcript | Sapat writes a `.txt` file beside the source | Review locally before sharing |
+| Redacted transcript | A separate script masks common sensitive values | Export only this reviewed copy |
+
+![Privacy-first transcription workflow](assets/images/20260520_privacy_first_sapat_transcription_flow.svg)
+
+Sapat is not a data-loss prevention product. It will not know whether a phrase
+is confidential to your company. The safe pattern is to treat the raw transcript
+as sensitive until a person or a local review script has checked it.
+
+## Materials Checklist
+
+Before you start, prepare:
+
+- a machine with [Daytona](https://github.com/daytonaio/daytona) installed;
+- access to a Git provider from Daytona;
+- Python 3.6 or newer in the workspace;
+- `ffmpeg` available in the workspace image;
+- one API key for OpenAI, Groq, or Azure OpenAI;
+- one short test recording that is safe to use for setup;
+- a decision about where redacted transcripts are allowed to go.
+
+Use a synthetic or non-sensitive recording for the first run. Do not test a new
+transcription flow with a real support call, legal conversation, patient note,
+or customer interview.
+
+## Step 1: Create the Daytona Workspace
+
+Create a workspace from the Sapat repository:
+
+```bash
+daytona create https://github.com/nkkko/sapat --code
+```
+
+Open a terminal in the workspace and inspect the project:
+
+```bash
+ls
+find src/sapat -maxdepth 3 -type f | sort
+```
+
+The files to notice are:
+
+- `src/sapat/script.py`, which defines the CLI options;
+- `src/sapat/transcription/base.py`, which converts video to MP3 and writes the transcript;
+- `src/sapat/transcription/openai.py`, `groq.py`, and `azure.py`, which send the audio to the selected provider.
+
+Install the project dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+pip install -e .
+```
+
+Check that the CLI is available:
+
+```bash
+sapat --help
+```
+
+You should see options such as `--language`, `--prompt`, `--temperature`,
+`--quality`, `--correct`, and `--api`.
+
+## Step 2: Configure One Provider
+
+Create a local `.env` file in the workspace. Choose one provider for the first
+run. Starting with one provider keeps the audit trail clear.
+
+For OpenAI:
+
+```env
+OPENAI_API_KEY=your_openai_api_key
+OPENAI_MODEL=whisper-1
+OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
+OPENAI_MODEL_NAME_CHAT=gpt-4o
+```
+
+For Groq:
+
+```env
+GROQCLOUD_API_KEY=your_groq_key
+GROQCLOUD_MODEL=whisper-large-v3-turbo
+GROQCLOUD_API_ENDPOINT=https://api.groq.com/openai/v1/audio/transcriptions
+GROQCLOUD_MODEL_NAME_CHAT=llama3-8b-8192
+```
+
+For Azure OpenAI:
+
+```env
+AZURE_OPENAI_API_KEY=your_azure_api_key
+AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
+AZURE_OPENAI_DEPLOYMENT_NAME_WHISPER=whisper
+AZURE_OPENAI_API_VERSION_WHISPER=2024-06-01
+AZURE_OPENAI_DEPLOYMENT_NAME_CHAT=gpt-4o
+AZURE_OPENAI_API_VERSION_CHAT=2023-03-15-preview
+```
+
+Then protect local files from accidental commits:
+
+```bash
+cat >> .git/info/exclude <<'EOF'
+.env
+recordings/
+transcripts/
+redacted/
+*.mp3
+*.mp4
+*.txt
+EOF
+```
+
+Using `.git/info/exclude` keeps the ignore rule local to your workspace. That is
+useful when you do not want to change the upstream project just to protect your
+test files.
+
+## Step 3: Prepare a Controlled Recording Folder
+
+Create folders for the workflow:
+
+```bash
+mkdir -p recordings transcripts redacted review
+```
+
+Put one short `.mp4` file in `recordings/`. For the first run, use a synthetic
+recording such as a short product demo you created specifically for testing.
+
+Create a run note before uploading anything:
+
+```bash
+cat > review/20260520-first-run.md <<'EOF'
+# First Sapat transcription run
+
+Provider: openai
+Input file: recordings/demo.mp4
+Approved for provider upload: yes
+Contains customer data: no
+Contains secrets or credentials: no
+Allowed downstream destination: redacted transcript only
+Reviewer: add-your-name
+EOF
+```
+
+This note looks simple, but it forces the most important decision before the
+provider call: is this recording allowed to leave the workspace for
+transcription?
+
+## Step 4: Run Sapat
+
+Run Sapat against the file:
+
+```bash
+sapat recordings/demo.mp4 \
+  --api openai \
+  --quality M \
+  --language en \
+  --prompt "Technical walkthrough. Preserve product names, acronyms, dates, and ticket IDs." \
+  --temperature 0.3
+```
+
+Replace `openai` with `groq` or `azure` if that is the provider you configured.
+
+Sapat should produce:
+
+```text
+recordings/demo.txt
+```
+
+Move the raw transcript into the working transcript folder:
+
+```bash
+mv recordings/demo.txt transcripts/demo.raw.txt
+```
+
+Read the transcript locally:
+
+```bash
+sed -n '1,160p' transcripts/demo.raw.txt
+```
+
+At this point, do not summarize it with another model and do not paste it into a
+ticket, document, chat, or search index. Treat it like the source recording
+until it has passed review.
+
+## Step 5: Add a Local Redaction Step
+
+Create a small redaction script:
+
+```bash
+cat > redact_transcript.py <<'PY'
+from pathlib import Path
+import re
+import sys
+
+PATTERNS = [
+    ("email", re.compile(r"\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b")),
+    ("phone", re.compile(r"(?<!\\d)(?:\\+?\\d[\\d .()\\-]{7,}\\d)(?!\\d)")),
+    ("token", re.compile(r"\\b(?:sk|pk|ghp|gho|xoxb|AKIA)[A-Za-z0-9_\\-]{12,}\\b")),
+    ("card", re.compile(r"\\b(?:\\d[ -]*?){13,19}\\b")),
+]
+
+if len(sys.argv) != 3:
+    print("usage: redact_transcript.py INPUT_FILE OUTPUT_FILE")
+    raise SystemExit(2)
+
+source = Path(sys.argv[1])
+target = Path(sys.argv[2])
+
+text = source.read_text(encoding="utf-8")
+counts = {}
+
+for label, pattern in PATTERNS:
+    text, count = pattern.subn(f"[REDACTED_{label.upper()}]", text)
+    counts[label] = count
+
+target.parent.mkdir(parents=True, exist_ok=True)
+target.write_text(text, encoding="utf-8")
+
+print("redaction summary")
+for label, count in counts.items():
+    print(f"{label}: {count}")
+PY
+```
+
+Run it:
+
+```bash
+python redact_transcript.py transcripts/demo.raw.txt redacted/demo.redacted.txt
+```
+
+Review the output:
+
+```bash
+sed -n '1,160p' redacted/demo.redacted.txt
+```
+
+This script is intentionally conservative and easy to inspect. It catches common
+patterns, not every possible sensitive phrase. Add project-specific terms to the
+script when your team knows what must be masked, such as customer names, internal
+repository names, contract IDs, or unreleased product names.
+
+## Step 6: Compare Raw and Redacted Output
+
+Use a local diff before exporting the text:
+
+```bash
+diff -u transcripts/demo.raw.txt redacted/demo.redacted.txt | sed -n '1,120p'
+```
+
+Then update the run note:
+
+```bash
+cat >> review/20260520-first-run.md <<'EOF'
+
+Raw transcript reviewed: yes
+Redaction script run: yes
+Redacted transcript manually checked: yes
+Export approved: yes
+EOF
+```
+
+Only the file in `redacted/` should move to the next step of your workflow. That
+next step might be a summary, a support knowledge base article, a search index,
+or a retrieval-augmented generation pipeline. The raw recording and raw
+transcript should stay in the workspace or in the controlled storage location
+your team already uses for sensitive data.
+
+## Optional: Use Sapat's Correction Pass Carefully
+
+Sapat includes a `--correct` option that sends the transcript text to a chat
+model for cleanup. That can improve punctuation and product spelling, but it is
+also another model call. Use it only after you have decided that the transcript
+content is allowed to go through that provider.
+
+Example:
+
+```bash
+sapat recordings/demo.mp4 \
+  --api groq \
+  --quality M \
+  --language en \
+  --prompt "Technical support call. Preserve product names and ticket IDs." \
+  --temperature 0.3 \
+  --correct
+```
+
+If you use `--correct`, run the same redaction and review steps against the
+corrected `.txt` file. A correction pass can add punctuation, but it can also
+rewrite wording. Do not assume corrected text is safer than raw text.
+
+## Common Issues and Troubleshooting
+
+**Problem:** `ffmpeg` is not found.
+
+**Solution:** Install `ffmpeg` in the workspace image or use a dev container
+that includes it. Sapat depends on `ffmpeg` for the MP3 conversion step.
+
+**Problem:** Sapat processes no files when you pass a directory.
+
+**Solution:** Confirm that the recordings use the `.mp4` extension. The current
+directory mode looks for `.mp4` files.
+
+**Problem:** The provider rejects the file.
+
+**Solution:** Try `--quality L` to create a smaller MP3, split long recordings,
+or test a short clip first. Sapat's OpenAI and Groq adapters also include a
+local file-size check before upload.
+
+**Problem:** The transcript keeps misspelling product names.
+
+**Solution:** Add a focused `--prompt` with the exact names, acronyms, and
+domain terms that should be preserved. Change one option at a time so you can
+tell whether the prompt, temperature, provider, or audio quality caused the
+improvement.
+
+**Problem:** The redaction script misses a sensitive phrase.
+
+**Solution:** Add a project-specific pattern and rerun the script. Generic
+regexes are only a first pass. Human review is still required for sensitive
+workflows.
+
+## Conclusion
+
+A useful transcription workflow is not just a command that creates a `.txt`
+file. It is a controlled path from recording to reviewed text. Daytona gives the
+workflow a repeatable workspace, Sapat handles the provider-specific
+transcription call, and a local redaction step gives teams a safer artifact to
+share downstream.
+
+The important habit is simple: keep raw recordings and raw transcripts private,
+document each provider upload decision, and export only text that has been
+reviewed and redacted for its intended destination.
+
+## References
+
+- [Sapat repository](https://github.com/nkkko/sapat)
+- [Daytona repository](https://github.com/daytonaio/daytona)
+- [Daytona content contribution guide](https://github.com/daytonaio/content/blob/main/CONTRIBUTING.md)

--- a/guides/assets/images/20260520_privacy_first_sapat_transcription_flow.svg
+++ b/guides/assets/images/20260520_privacy_first_sapat_transcription_flow.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="520" viewBox="0 0 1200 520" role="img" aria-labelledby="title desc">
+  <title id="title">Privacy-first transcription workflow with Daytona and Sapat</title>
+  <desc id="desc">A five-step workflow showing recordings entering a Daytona workspace, being transcribed by Sapat, checked, redacted, and exported.</desc>
+  <rect width="1200" height="520" rx="32" fill="#f8fafc"/>
+  <rect x="46" y="64" width="1108" height="392" rx="28" fill="#e2e8f0"/>
+  <rect x="88" y="112" width="180" height="240" rx="24" fill="#ffffff" stroke="#94a3b8" stroke-width="3"/>
+  <rect x="298" y="112" width="180" height="240" rx="24" fill="#ffffff" stroke="#94a3b8" stroke-width="3"/>
+  <rect x="508" y="112" width="180" height="240" rx="24" fill="#ffffff" stroke="#94a3b8" stroke-width="3"/>
+  <rect x="718" y="112" width="180" height="240" rx="24" fill="#ffffff" stroke="#94a3b8" stroke-width="3"/>
+  <rect x="928" y="112" width="180" height="240" rx="24" fill="#ffffff" stroke="#94a3b8" stroke-width="3"/>
+  <path d="M268 232h30" stroke="#334155" stroke-width="5" stroke-linecap="round"/>
+  <path d="m292 220 14 12-14 12" fill="none" stroke="#334155" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M478 232h30" stroke="#334155" stroke-width="5" stroke-linecap="round"/>
+  <path d="m502 220 14 12-14 12" fill="none" stroke="#334155" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M688 232h30" stroke="#334155" stroke-width="5" stroke-linecap="round"/>
+  <path d="m712 220 14 12-14 12" fill="none" stroke="#334155" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M898 232h30" stroke="#334155" stroke-width="5" stroke-linecap="round"/>
+  <path d="m922 220 14 12-14 12" fill="none" stroke="#334155" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="178" cy="174" r="34" fill="#38bdf8"/>
+  <path d="M166 174h24m-12-12v24" stroke="#ffffff" stroke-width="8" stroke-linecap="round"/>
+  <circle cx="388" cy="174" r="34" fill="#22c55e"/>
+  <path d="M372 177 384 190l24-32" fill="none" stroke="#ffffff" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="598" cy="174" r="34" fill="#f59e0b"/>
+  <path d="M584 166h28v16h-28z" fill="none" stroke="#ffffff" stroke-width="7" stroke-linejoin="round"/>
+  <path d="M590 166v-8h16v8" fill="none" stroke="#ffffff" stroke-width="7" stroke-linecap="round"/>
+  <circle cx="808" cy="174" r="34" fill="#ef4444"/>
+  <path d="M792 162h32M792 174h32M792 186h20" stroke="#ffffff" stroke-width="7" stroke-linecap="round"/>
+  <circle cx="1018" cy="174" r="34" fill="#6366f1"/>
+  <path d="M1002 174h32M1018 158v32" stroke="#ffffff" stroke-width="7" stroke-linecap="round"/>
+  <text x="178" y="260" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="28" font-weight="700" fill="#0f172a">Recordings</text>
+  <text x="178" y="300" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="20" fill="#475569">Keep raw files</text>
+  <text x="178" y="326" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="20" fill="#475569">inside workspace</text>
+  <text x="388" y="260" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="28" font-weight="700" fill="#0f172a">Daytona</text>
+  <text x="388" y="300" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="20" fill="#475569">Repeatable tools</text>
+  <text x="388" y="326" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="20" fill="#475569">and local secrets</text>
+  <text x="598" y="260" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="28" font-weight="700" fill="#0f172a">Sapat</text>
+  <text x="598" y="300" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="20" fill="#475569">Convert, send,</text>
+  <text x="598" y="326" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="20" fill="#475569">and save .txt</text>
+  <text x="808" y="260" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="28" font-weight="700" fill="#0f172a">Redact</text>
+  <text x="808" y="300" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="20" fill="#475569">Mask common</text>
+  <text x="808" y="326" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="20" fill="#475569">sensitive data</text>
+  <text x="1018" y="260" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="28" font-weight="700" fill="#0f172a">Export</text>
+  <text x="1018" y="300" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="20" fill="#475569">Share only</text>
+  <text x="1018" y="326" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="20" fill="#475569">reviewed text</text>
+  <text x="600" y="418" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="24" font-weight="700" fill="#0f172a">Raw audio stays controlled; only checked and redacted transcripts move downstream.</text>
+</svg>


### PR DESCRIPTION
/claim #13

## Summary

- Add a Daytona guide for running a privacy-first Sapat transcription workflow.
- Add a transcript redaction definition for the Daytona definitions library.
- Add first-time author metadata plus simple SVG assets for the guide and author profile.

## Validation

- `npx markdownlint definitions/20260520_definition_transcript_redaction.md guides/20260520_guide_privacy_first_sapat_transcription.md authors/daniel-romero-sanchez.md`
- `git diff --cached --check` before commit

Note: `npm run lint:md` currently reports pre-existing Markdown issues in older repository files outside this PR. The new Markdown files pass targeted linting.

## AI Assistance

Tools used: AI-assisted writing support
How extensively: Assisted source inspection, drafting, and validation; final content was reviewed before submission.