### PR TITLE
Run Gemini transcription with Sapat in Daytona

### DIFF
--- a/authors/assets/haohui-xie.svg
+++ b/authors/assets/haohui-xie.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Haohui Xie avatar</title>
+  <desc id="desc">A simple geometric avatar with HX initials.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1E3A8A"/>
+      <stop offset="55%" stop-color="#2563EB"/>
+      <stop offset="100%" stop-color="#06B6D4"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="96" fill="url(#bg)"/>
+  <circle cx="256" cy="188" r="92" fill="#DBEAFE" opacity="0.95"/>
+  <path d="M112 440c20-90 82-142 144-142s124 52 144 142" fill="#EFF6FF" opacity="0.95"/>
+  <text x="256" y="292" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="112" font-weight="800" fill="#0F172A">HX</text>
+</svg>

--- a/authors/haohui_xie.md
+++ b/authors/haohui_xie.md
@@ -1,0 +1,3 @@
+Author: Haohui Xie Title: AI Engineering Contributor
+Description: Haohui Xie works on AI engineering, speech technology, and agent workflows. He enjoys turning rough experiments into reproducible developer guides with clear setup steps, validation checks, and practical troubleshooting notes for teams building with modern AI tools.
+Author Image: ![haohui-xie](./assets/haohui-xie.svg) Author LinkedIn: Author Twitter: Company Name: Independent Contributor Company Description: Independent AI engineering and open-source contributor. Company Logo Dark: Company Logo White:

--- a/definitions/20260521_definition_gemini_audio_transcription.md
+++ b/definitions/20260521_definition_gemini_audio_transcription.md
@@ -1,0 +1,20 @@
+---
+title: 'Gemini Audio Transcription'
+description: 'Using Google Gemini multimodal models to convert speech in audio or video recordings into text transcripts.'
+date: 2026-05-21
+author: 'Haohui Xie'
+---
+
+# Gemini Audio Transcription
+
+## Definition
+
+Gemini audio transcription is the use of Google's Gemini multimodal models to convert spoken audio into text. Instead of sending a file to a dedicated Whisper-compatible endpoint, a developer can send audio and text instructions together to Gemini's `generateContent` API.
+The model then returns transcript text that can be reviewed or passed to downstream tools.
+
+## Context and Usage
+
+In an engineering workflow, Gemini audio transcription is useful when the transcript needs both speech recognition and instruction-following context. A developer can provide hints such as product names, repository names, acronyms, or the dominant language of the recording.
+The model receives those hints alongside the audio and returns a transcript that can be reviewed, searched, summarized, or turned into follow-up tasks.
+
+When using Gemini for transcription, teams should handle API keys as secrets, validate file-size limits, and run a short sample before batching many recordings. For privacy-sensitive recordings, confirm that the provider and project settings match the organization's data policy before uploading audio.

--- a/guides/20260521_guide_run_gemini_transcription_with_sapat_in_daytona.md
+++ b/guides/20260521_guide_run_gemini_transcription_with_sapat_in_daytona.md
@@ -1,0 +1,380 @@
+---
+title: "Run Gemini Transcription With Sapat in Daytona"
+description: "Build a reproducible Daytona workspace for Sapat, add Gemini audio transcription, and validate transcripts without leaking secrets."
+date: 2026-05-21
+author: "Haohui Xie"
+tags: ["daytona", "sapat", "gemini", "transcription"]
+---
+
+# Run Gemini Transcription With Sapat in Daytona
+
+# Introduction
+
+Audio and video transcription is now a normal part of AI engineering work. Product demos,
+research interviews, incident calls, customer feedback, and internal walkthroughs all become
+more useful after they are converted into searchable text. The hard part is not only sending a
+recording to a model. The hard part is creating a repeatable workflow that another engineer can
+run with the same dependencies, the same command-line flags, and the same secret-handling rules.
+
+This guide shows how to run [Sapat](https://github.com/nibzard/sapat), a Python video
+transcription tool, inside a Daytona workspace and route transcription through Google Gemini.
+The companion Sapat implementation adds `--api gemini` with the Gemini Developer API, so AI
+engineers can test a multimodal transcription path next to the existing OpenAI, Groq, and Azure
+providers. You will create a Daytona workspace, configure `GEMINI_API_KEY`, run a single-file
+transcription, validate the output, and troubleshoot the most common failure modes.
+
+## TL;DR
+
+- **Use Daytona for reproducibility**: Run Sapat in a clean workspace with the same Python,
+  `ffmpeg`, and package setup each time.
+- **Use Gemini as another provider**: The companion Sapat PR adds `sapat --api gemini` without
+  adding a new runtime dependency.
+- **Keep secrets out of Git**: Store `GEMINI_API_KEY` in `.env` for local tests or in your
+  team's approved secret manager, never in commits or article examples.
+- **Validate before batching**: Start with one short recording, inspect the `.txt` output, then
+  process a directory when the prompt and quality settings are stable.
+
+## What You Will Build
+
+The workflow has five moving parts:
+
+![Gemini Sapat Daytona workflow](assets/20260521_gemini_sapat_daytona_workflow.svg)
+
+1. Daytona creates an isolated workspace from the Sapat repository.
+2. Sapat receives a video file or a directory of `.mp4` files.
+3. Sapat uses `ffmpeg` to convert each recording to an MP3 sidecar.
+4. The Gemini provider sends inline audio to the Gemini `generateContent` endpoint.
+5. Sapat writes the transcript to a `.txt` file beside the original recording.
+
+The companion implementation is in
+[`nibzard/sapat#35`](https://github.com/nibzard/sapat/pull/35). Until that PR is merged, use the
+feature branch from `xhh678876/sapat` for the hands-on steps below.
+
+## Prerequisites
+
+You need the following before starting:
+
+- A GitHub account connected to Daytona.
+- [Daytona](https://www.daytona.io/docs/installation/installation/) installed locally.
+- Docker available on the machine that runs Daytona.
+- A Gemini API key from [Google AI Studio](https://aistudio.google.com/app/apikey).
+- A short `.mp4`, `.mp3`, `.wav`, or `.flac` recording for the first smoke test.
+- Basic familiarity with [APIs](../definitions/20241212_definition_api.md), Python, and terminal
+  commands.
+
+Gemini inline audio requests have a request-size ceiling. The Sapat Gemini provider uses a
+conservative raw file limit of 14 MB because base64 encoding expands audio by roughly one third.
+For long meetings, split the recording first or use a provider flow that supports uploaded files.
+
+## Step 1: Create a Daytona Workspace for Sapat
+
+Start Daytona if it is not already running:
+
+```bash
+daytona server
+```
+
+Create a workspace from the fork that contains the Gemini provider branch:
+
+```bash
+daytona create https://github.com/xhh678876/sapat --code
+```
+
+When the workspace opens, switch to the Gemini branch:
+
+```bash
+git checkout feat/gemini-transcription-provider
+```
+
+If the companion PR has already been merged by the time you read this, use the upstream
+repository instead:
+
+```bash
+daytona create https://github.com/nibzard/sapat --code
+```
+
+Daytona gives you a clean environment, but it does not remove the need to verify the basics.
+Confirm that you are in the Sapat project root:
+
+```bash
+pwd
+git status --short
+```
+
+## Step 2: Install Sapat in Editable Mode
+
+Create a virtual environment and install the package:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e .
+```
+
+Confirm the CLI exposes the Gemini provider:
+
+```bash
+sapat --help
+```
+
+You should see `gemini` listed in the `--api` option beside `openai`, `groq`, and `azure`.
+
+Sapat depends on `ffmpeg` for video-to-audio conversion. The repository dev container installs it,
+but you can verify it directly:
+
+```bash
+ffmpeg -version
+```
+
+If the command is missing inside the workspace, install it with your package manager. On Debian or
+Ubuntu based images:
+
+```bash
+sudo apt update
+sudo apt install -y ffmpeg
+```
+
+## Step 3: Configure Gemini Without Committing Secrets
+
+Copy the example environment file:
+
+```bash
+cp .env.example .env
+```
+
+Open `.env` and add the Gemini values:
+
+```bash
+GEMINI_API_KEY=your_gemini_api_key_here
+GEMINI_MODEL=gemini-2.0-flash
+GEMINI_API_ENDPOINT_TEMPLATE=https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent
+```
+
+The only required value is `GEMINI_API_KEY`. `GEMINI_MODEL` defaults to `gemini-2.0-flash`, and the
+endpoint template defaults to the Gemini Developer API `generateContent` route.
+
+Before you continue, check that `.env` is not staged:
+
+```bash
+git status --short
+```
+
+If you see `.env` in the output, stop and add it to your local ignore rules before committing any
+work. API keys should stay in the workspace, not in Git.
+
+## Step 4: Understand How the Gemini Provider Works
+
+The provider keeps Sapat's existing shape. You still run the same `sapat` command, choose a
+provider with `--api`, and receive a `.txt` transcript next to the input file.
+
+Under the hood, the Gemini provider does four things:
+
+1. Validates that the converted audio file exists and uses `.mp3`, `.wav`, or `.flac`.
+2. Rejects raw files above 14 MB to stay under Gemini inline request limits after base64 encoding.
+3. Builds a Gemini prompt from the `--language` hint and optional `--prompt` guidance.
+4. Sends JSON to `generateContent` with the audio in an `inline_data` part.
+
+That last point is different from OpenAI-style Whisper endpoints. With Whisper-compatible APIs,
+Sapat sends a multipart form upload. With Gemini, Sapat sends a JSON request containing both text
+instructions and base64-encoded audio.
+
+## Step 5: Run a Single-File Transcription
+
+Start with a short file. Put it in a folder named `recordings`:
+
+```bash
+mkdir -p recordings
+# Copy your test file into recordings/demo.mp4, or use your own filename.
+```
+
+Run Sapat with Gemini:
+
+```bash
+sapat recordings/demo.mp4 \
+  --api gemini \
+  --quality M \
+  --language en \
+  --prompt "Product names: Daytona, Sapat, Gemini. Keep technical terms exact."
+```
+
+Sapat will print progress messages similar to this:
+
+```text
+Processing recordings/demo.mp4
+Conversion to MP3 completed
+Transcription completed
+Transcription saved to recordings/demo.txt
+```
+
+Open the transcript:
+
+```bash
+sed -n '1,120p' recordings/demo.txt
+```
+
+Check three things before moving on:
+
+- The transcript is present and not empty.
+- Product names such as Daytona, Sapat, and Gemini are spelled correctly.
+- The transcript does not include model commentary like "Here is the transcription".
+
+The Gemini prompt asks the model to return only transcript text. If you still see wrapper text,
+make the user prompt stricter and run the same short file again.
+
+## Step 6: Use Prompt Hints for Engineering Recordings
+
+Transcription quality often depends on context. Engineering recordings contain repository names,
+API names, incident IDs, and acronyms that are easy to mishear. Sapat exposes `--prompt` so you can
+pass those hints without editing the source code.
+
+For a bug reproduction video:
+
+```bash
+sapat recordings/bug-repro.mp4 \
+  --api gemini \
+  --language en \
+  --prompt "Terms: Daytona workspace, devcontainer, GEMINI_API_KEY, generateContent, ffmpeg. Preserve CLI flags exactly."
+```
+
+For a research interview:
+
+```bash
+sapat recordings/interview.mp4 \
+  --api gemini \
+  --language en \
+  --prompt "This is an AI engineering interview. Preserve model names, dataset names, and benchmark names exactly."
+```
+
+For a multilingual clip, set the language hint to the dominant language and add context in the
+prompt:
+
+```bash
+sapat recordings/mixed-language-demo.mp4 \
+  --api gemini \
+  --language zh \
+  --prompt "The recording mixes Chinese and English. Preserve English API names exactly."
+```
+
+Do not put private customer details in the prompt unless your data policy allows it. The prompt is
+sent to the transcription provider along with the audio.
+
+## Step 7: Run the Optional Correction Pass
+
+The companion provider also supports Sapat's `--correct` flag. This performs a second Gemini call
+that asks for light cleanup after transcription.
+
+```bash
+sapat recordings/demo.mp4 \
+  --api gemini \
+  --quality M \
+  --language en \
+  --prompt "Product names: Daytona, Sapat, Gemini." \
+  --correct
+```
+
+Use `--correct` when you need cleaner punctuation or capitalization. Skip it when you need a more
+literal transcript for legal, research, or audit workflows because the cleanup pass can smooth over
+small hesitations or repeated words.
+
+## Step 8: Process a Directory
+
+After one short file succeeds, process a batch directory:
+
+```bash
+sapat recordings \
+  --api gemini \
+  --quality M \
+  --language en \
+  --prompt "Engineering demo recordings. Preserve CLI commands and environment variable names."
+```
+
+Sapat processes `.mp4` files in the directory and writes one `.txt` file per recording. Keep the
+first batch small. A good pattern is:
+
+1. Run one file.
+2. Review the transcript.
+3. Adjust `--prompt` and `--quality`.
+4. Run three to five files.
+5. Only then run the full folder.
+
+This protects your API budget and makes quality problems visible before they affect a whole batch.
+
+## Step 9: Validate the Provider Without Spending API Credits
+
+The companion Sapat PR includes mocked unit tests. They validate request construction and error
+handling without sending audio to Gemini:
+
+```bash
+python -m unittest discover -s tests -v
+python -m compileall src tests
+git diff --check
+```
+
+The tests cover:
+
+- Inline base64 audio construction.
+- `GEMINI_API_KEY` validation.
+- Gemini response parsing.
+- Request failures and non-JSON responses.
+- Safety or prompt-feedback blocks.
+- Custom endpoint templates.
+- CLI routing for `--api gemini`.
+
+Run these checks before changing the provider. They are faster than a real transcription call and
+safe to run in CI.
+
+## Common Issues and Troubleshooting
+
+**Problem: `GEMINI_API_KEY is required`.**
+
+**Solution:** Add `GEMINI_API_KEY` to `.env`, restart the shell if needed, and run the command from
+the Sapat project root so `python-dotenv` can load the file.
+
+**Problem: The request fails because the file is too large.**
+
+**Solution:** Use a shorter clip, lower the MP3 quality with `--quality L`, or split the recording
+before running Sapat. The Gemini provider intentionally keeps raw files below 14 MB to stay under
+inline request limits after base64 encoding.
+
+**Problem: `ffmpeg` is not found.**
+
+**Solution:** Install `ffmpeg` in the workspace. For Debian or Ubuntu images, run
+`sudo apt install -y ffmpeg`. Then retry the Sapat command.
+
+**Problem: The transcript is empty or Gemini returns no candidates.**
+
+**Solution:** Check whether the audio is silent, too short, or blocked by provider safety feedback.
+Try a known-good short clip and simplify the prompt. If the error includes prompt feedback, remove
+sensitive or policy-triggering instructions and rerun.
+
+**Problem: Technical names are misspelled.**
+
+**Solution:** Add a compact glossary to `--prompt`. Put product names, repository names, CLI flags,
+and unusual acronyms in the prompt before the first run.
+
+**Problem: The transcript includes extra narration from the model.**
+
+**Solution:** Strengthen the prompt with "Return only the transcript text" and rerun a short sample.
+The provider already includes that instruction, but extra user context can sometimes distract a
+multimodal model.
+
+## Conclusion
+
+You now have a reproducible AI transcription workflow that runs Sapat inside Daytona and uses
+Google Gemini as a provider. The important part is not just the API call. The important part is the
+repeatable loop: create the workspace, configure secrets safely, transcribe one short file, review
+the output, tune the prompt, and only then batch-process a folder.
+
+Gemini is a useful addition because it gives Sapat another multimodal model path without changing
+the CLI workflow. If you later compare providers, keep the input file, language hint, prompt, and
+quality setting constant. That makes the transcript differences easier to attribute to the provider
+instead of the environment.
+
+## References
+
+- [Sapat repository](https://github.com/nibzard/sapat)
+- [Companion Gemini provider PR](https://github.com/nibzard/sapat/pull/35)
+- [Daytona installation documentation](https://www.daytona.io/docs/installation/installation/)
+- [Google AI Studio API keys](https://aistudio.google.com/app/apikey)
+- [Gemini audio transcription definition](../definitions/20260521_definition_gemini_audio_transcription.md)

--- a/guides/assets/20260521_gemini_sapat_daytona_workflow.svg
+++ b/guides/assets/20260521_gemini_sapat_daytona_workflow.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="560" viewBox="0 0 1200 560" role="img" aria-labelledby="title desc">
+  <title id="title">Gemini Sapat Daytona transcription workflow</title>
+  <desc id="desc">Daytona creates the workspace, Sapat converts video to MP3, Gemini transcribes audio, and Sapat writes text output.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#020617"/>
+      <stop offset="100%" stop-color="#0F172A"/>
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1E293B"/>
+      <stop offset="100%" stop-color="#111827"/>
+    </linearGradient>
+    <marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M2 2 L10 6 L2 10 Z" fill="#38BDF8"/>
+    </marker>
+  </defs>
+  <rect width="1200" height="560" fill="url(#bg)"/>
+  <text x="600" y="72" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="36" font-weight="800" fill="#E0F2FE">Gemini Transcription With Sapat in Daytona</text>
+  <text x="600" y="110" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="18" fill="#94A3B8">A reproducible workspace-to-transcript workflow for AI engineers</text>
+
+  <g font-family="Inter, Arial, sans-serif">
+    <rect x="70" y="190" width="210" height="150" rx="24" fill="url(#card)" stroke="#38BDF8" stroke-width="2"/>
+    <text x="175" y="238" text-anchor="middle" font-size="24" font-weight="800" fill="#F8FAFC">Daytona</text>
+    <text x="175" y="272" text-anchor="middle" font-size="16" fill="#CBD5E1">Create isolated</text>
+    <text x="175" y="296" text-anchor="middle" font-size="16" fill="#CBD5E1">Sapat workspace</text>
+
+    <rect x="360" y="190" width="210" height="150" rx="24" fill="url(#card)" stroke="#A78BFA" stroke-width="2"/>
+    <text x="465" y="238" text-anchor="middle" font-size="24" font-weight="800" fill="#F8FAFC">Sapat CLI</text>
+    <text x="465" y="272" text-anchor="middle" font-size="16" fill="#CBD5E1">Convert video</text>
+    <text x="465" y="296" text-anchor="middle" font-size="16" fill="#CBD5E1">to MP3 audio</text>
+
+    <rect x="650" y="190" width="210" height="150" rx="24" fill="url(#card)" stroke="#22C55E" stroke-width="2"/>
+    <text x="755" y="238" text-anchor="middle" font-size="24" font-weight="800" fill="#F8FAFC">Gemini API</text>
+    <text x="755" y="272" text-anchor="middle" font-size="16" fill="#CBD5E1">Transcribe with</text>
+    <text x="755" y="296" text-anchor="middle" font-size="16" fill="#CBD5E1">inline audio</text>
+
+    <rect x="940" y="190" width="210" height="150" rx="24" fill="url(#card)" stroke="#F59E0B" stroke-width="2"/>
+    <text x="1045" y="238" text-anchor="middle" font-size="24" font-weight="800" fill="#F8FAFC">Transcript</text>
+    <text x="1045" y="272" text-anchor="middle" font-size="16" fill="#CBD5E1">Review, search,</text>
+    <text x="1045" y="296" text-anchor="middle" font-size="16" fill="#CBD5E1">and hand off</text>
+  </g>
+
+  <path d="M285 265 H350" stroke="#38BDF8" stroke-width="4" marker-end="url(#arrow)"/>
+  <path d="M575 265 H640" stroke="#38BDF8" stroke-width="4" marker-end="url(#arrow)"/>
+  <path d="M865 265 H930" stroke="#38BDF8" stroke-width="4" marker-end="url(#arrow)"/>
+
+  <rect x="190" y="410" width="820" height="64" rx="18" fill="#0B1220" stroke="#334155"/>
+  <text x="600" y="450" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="18" fill="#BAE6FD">Keep GEMINI_API_KEY in .env or an approved secret manager; validate one short clip before batching.</text>
+</svg>


### PR DESCRIPTION
/claim #13

## Summary
- Adds a 1,900+ word Daytona guide for running a Gemini-backed Sapat transcription workflow in a reproducible workspace.
- Adds a companion definition for Gemini audio transcription.
- Adds first-time author metadata and original SVG assets for the workflow diagram and author avatar.
- Links the companion Sapat provider implementation: https://github.com/nibzard/sapat/pull/35

## Why this is distinct for #13
I checked the current issue comments and Sapat/content PRs before starting. I did not find an existing Gemini provider slice. This guide focuses on Gemini's multimodal `generateContent` flow, inline audio size limits, prompt hints for engineering recordings, and validation without spending API credits.

## Validation
- `npx markdownlint guides/20260521_guide_run_gemini_transcription_with_sapat_in_daytona.md definitions/20260521_definition_gemini_audio_transcription.md authors/haohui_xie.md`
- `git diff --check`

## Companion Sapat validation
- `python -m venv .venv && .venv/bin/python -m pip install -q -e .`
- `.venv/bin/python -m unittest discover -s tests -v` (12 tests)
- `.venv/bin/python -m compileall src tests`
- `git diff --check`

AI-assisted with Codex and Claude Code; I reviewed the article, provider diff, and validation locally before submitting.
